### PR TITLE
Pad minutes to two digits.

### DIFF
--- a/standup/static/js/standup.js
+++ b/standup/static/js/standup.js
@@ -18,6 +18,9 @@ function fixTimezones() {
             hours -= 12;
             ampm = 'pm';
         }
+        if (minutes < 10) { // single digit
+            minutes = '0' + minutes;
+        }
         $t.text(hours + ':' + minutes + ' ' + ampm);
     });
 }


### PR DESCRIPTION
Because "12:1 pm" is a silly time.
