### PR TITLE
Fix tag detection.

### DIFF
--- a/standup/app.py
+++ b/standup/app.py
@@ -396,6 +396,9 @@ def gravatar_url(email):
     return 'http://www.gravatar.com/avatar/' + hash
 
 
+TAG_TMPL = '{0} <span class="tag tag-{1}">{1}</span>'
+
+
 @app.template_filter('format_update')
 def format_update(update, project=None):
     def set_target(attrs, new=False):
@@ -418,13 +421,14 @@ def format_update(update, project=None):
 
     formatted = linkify(formatted, target='_blank')
 
-    # Search for tags on the original, unformatted string.
-    tags = re.findall(r'(?:^|[^\w\\/])#([a-zA-Z_\.-]+)(?:\b|$)', update)
+    # Search for tags on the original, unformatted string. A tag must start
+    # with a letter.
+    tags = re.findall(r'(?:^|[^\w\\/])#([a-zA-Z][a-zA-Z0-9_\.-]*)(?:\b|$)',
+                      update)
     if tags:
         tags_html = ''
         for tag in tags:
-            tags_html = '{0} <span class="tag tag-{1}">{1}</span>'.format(
-                tags_html, tag)
+            tags_html = TAG_TMPL.format(tags_html, tag)
         formatted = '%s %s' % (tags_html, formatted)
 
     return formatted

--- a/standup/tests/test_app.py
+++ b/standup/tests/test_app.py
@@ -6,7 +6,7 @@ import unittest
 from nose.tools import ok_, eq_
 
 from standup import app
-from standup.app import User, Project, Status, format_update
+from standup.app import User, Project, Status, format_update, TAG_TMPL
 from standup import settings
 from standup.tests import status, user
 
@@ -256,3 +256,15 @@ class AppTestCase(unittest.TestCase):
             '/api/v1/user/%s/' % u.id, data=data,
             content_type='application/json')
         self.assertEqual(response.status_code, 403)
+
+
+class FormatUpdateTest(unittest.TestCase):
+    def test_tags(self):
+        # Test valid tags.
+        for tag in ('#t', '#tag', '#TAG', '#tag123'):
+            expected = '%s %s' % (TAG_TMPL.format('', tag[1:]), tag)
+            eq_(format_update(tag), expected)
+
+        # Test invalid tags.
+        for tag in ('#1', '#.abc', '#?abc'):
+            eq_(format_update(tag), tag)


### PR DESCRIPTION
Tags must start with a letter, but then can contain any combination of
letters, numbers, and '_', '.' and '-'.

Also, this adds a basic test to verify that's true.

r?
