### PR TITLE
markdown support - solves most of the #16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask==0.9
 Flask-SQLAlchemy==0.16
 Flask-Script==0.3.3
+Flask-Markdown==0.3
 Jinja2==2.6
 SQLAlchemy==0.7.8
 Tempita==0.5.1

--- a/standup/app.py
+++ b/standup/app.py
@@ -6,10 +6,11 @@ from functools import wraps
 from urllib import urlencode
 
 import browserid
-from bleach import clean, linkify
+from bleach import clean
 from flask import (Flask, render_template, request, url_for, jsonify,
                    make_response, session, redirect)
 from flask.ext.sqlalchemy import SQLAlchemy
+from flaskext.markdown import Markdown
 
 import settings
 
@@ -17,6 +18,7 @@ from standup.utils import slugify
 
 
 app = Flask(__name__)
+Markdown(app)
 app.debug = getattr(settings, 'DEBUG', False)
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get(
     'DATABASE_URL', 'sqlite:///standup_app.db')
@@ -532,8 +534,6 @@ def format_update(update, project=None):
         formatted = re.sub(r'(pull|pr) #?(\d+)',
             r'<a href="%s/pull/\2">\1 \2</a>' % project.repo_url, formatted,
             flags=re.I)
-
-    formatted = linkify(formatted, target='_blank')
 
     # Search for tags on the original, unformatted string. A tag must start
     # with a letter.

--- a/standup/templates/includes/macros.html
+++ b/standup/templates/includes/macros.html
@@ -61,7 +61,7 @@
           <ul class="bubble">
     {% endif %}
             <li class="cf">
-              <div class="update">{{ status.content_html|format_update(status.project)|safe }}</div>
+              <div class="update">{{ status.content_html|format_update(status.project)|safe|urlize|markdown }}</div>
               <div class="update-meta">
                 <a class="post-time" href="{{ url_for('status', id=status.id) }}">
                   <time datetime="{{ status.created|dateformat('%Y-%m-%dT%H:%M:%SZ') }}">


### PR DESCRIPTION
I removed linkify from formated_updates functions because it conflicts with markdown, since it linkifies before markdown template filter applies. Instead I used urlize which respects markdown syntax.
