### PR TITLE
Tweak tag_html so that it displays tags in original casing

### DIFF
--- a/standup/app.py
+++ b/standup/app.py
@@ -535,7 +535,7 @@ def gravatar_url(email, size=None):
     return url
 
 
-TAG_TMPL = '{0} <span class="tag tag-{1}">{1}</span>'
+TAG_TMPL = '{0} <span class="tag tag-{1}">{2}</span>'
 
 
 @app.template_filter('format_update')
@@ -568,7 +568,7 @@ def format_update(update, project=None):
     if tags:
         tags_html = ''
         for tag in tags:
-            tags_html = TAG_TMPL.format(tags_html, tag.lower())
+            tags_html = TAG_TMPL.format(tags_html, tag.lower(), tag)
         formatted = '%s <div class="tags">%s</div>' % (formatted, tags_html)
 
     return formatted


### PR DESCRIPTION
This tweaks 83bbb8f slightly so that the css class is lowercase, but the display is in whatever case it was in.

r?
