### PR TITLE
Change standup.app to standup.main; pep-8 cleanup

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,10 +2,11 @@
 import os
 
 from flask.ext.script import Manager
+
 from migrate.exceptions import DatabaseAlreadyControlledError
 from migrate.versioning import api as migrate_api
 
-from standup.app import db
+from standup.main import db
 from standup.wsgi import app
 from standup.apps.status.models import Project, Status
 from standup.apps.users.models import Team, User

--- a/standup/apps/api/decorators.py
+++ b/standup/apps/api/decorators.py
@@ -1,6 +1,9 @@
-from flask import jsonify, make_response, request
 from functools import wraps
+
+from flask import jsonify, make_response, request
+
 from standup import settings
+
 
 def api_key_required(view):
     @wraps(view)

--- a/standup/apps/api/views.py
+++ b/standup/apps/api/views.py
@@ -1,11 +1,14 @@
 from flask import Blueprint, jsonify, make_response, request
-from standup.app import db
-from standup.utils import slugify
+
 from standup.apps.api.decorators import api_key_required
 from standup.apps.status.models import Project, Status
 from standup.apps.users.models import User
+from standup.main import db
+from standup.utils import slugify
+
 
 blueprint = Blueprint('api_v1', __name__, url_prefix='/api/v1')
+
 
 @blueprint.route('/feed/', methods=['GET'])
 def get_statuses():
@@ -13,11 +16,12 @@ def get_statuses():
 
     Returns id, user (the name), project name and timestamp of statuses.
 
-    The amount of items to return is determined by the limit argument (defaults
-    to 20):
-    /api/v1/feed/?limit=20
+    The amount of items to return is determined by the limit argument
+    (defaults to 20)::
 
-    An example of the JSON:
+        /api/v1/feed/?limit=20
+
+    An example of the JSON::
 
         {
             "1": {
@@ -27,8 +31,8 @@ def get_statuses():
                 "timestamp": "2013-01-11T21:13:30.806236"
             }
         }
-    """
 
+    """
     limit = request.args.get('limit', 20)
 
     statuses = Status.query.filter(Status.reply_to == None).\
@@ -68,6 +72,7 @@ def create_status():
             "content": "working on bug 123456",
             "api_key": "qwertyuiopasdfghjklzxcvbnm1234567890"
         }
+
     """
     # The data we need
     username = request.json.get('user')
@@ -136,12 +141,13 @@ def delete_status(id):
     * user (the username)
     * api_key
 
-    An example of the JSON:
+    An example of the JSON::
 
         {
             "user": "r1cky",
             "api_key": "qwertyuiopasdfghjklzxcvbnm1234567890"
         }
+
     """
     # The data we need
     user = request.json.get('user')
@@ -185,15 +191,15 @@ def update_user(username):
     * email
     * github_handle
 
-    An example of the JSON:
+    An example of the JSON::
 
         {
             "user": "r1cky",
             "email": "ricky@email.com"
             "api_key": "qwertyuiopasdfghjklzxcvbnm1234567890"
         }
-    """
 
+    """
     # The data we need
     authorname = request.json.get('user')
 

--- a/standup/apps/api2/views.py
+++ b/standup/apps/api2/views.py
@@ -1,8 +1,11 @@
 from flask import Blueprint, jsonify
-from standup.app import db
+
 from standup.apps.status.models import Status
+from standup.main import db
+
 
 blueprint = Blueprint('api_v2', __name__, url_prefix='/api/v2')
+
 
 @blueprint.route('/', methods=['GET'])
 @blueprint.route('/feed/', methods=['GET'])
@@ -11,11 +14,12 @@ def feed(request):
 
     Returns id, user (the name), project name and timestamp of statuses.
 
-    The amount of items to return is determined by the limit argument (defaults
-    to 20):
-    /api/v2/feed/?limit=20
+    The amount of items to return is determined by the limit argument
+    (defaults to 20)::
 
-    An example of the JSON:
+        /api/v2/feed/?limit=20
+
+    An example of the JSON::
 
         {
             "1": {
@@ -25,12 +29,12 @@ def feed(request):
                 "timestamp": "2013-01-11T21:13:30.806236"
             }
         }
-    """
 
+    """
     limit = request.args.get('limit', 20)
 
-    statuses = Status.query.filter(Status.reply_to == None).\
-    order_by(db.desc(Status.created)).limit(limit)
+    statuses = (Status.query.filter(Status.reply_to == None)
+                      .order_by(db.desc(Status.created)).limit(limit))
 
     data={}
     for row in statuses:

--- a/standup/apps/landings/views.py
+++ b/standup/apps/landings/views.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, render_template
 
+
 blueprint = Blueprint('landings', __name__)
+
 
 @blueprint.route('/help')
 def help():

--- a/standup/apps/status/helpers.py
+++ b/standup/apps/status/helpers.py
@@ -1,6 +1,7 @@
 import re
 from datetime import date, datetime, timedelta
 
+
 def paginate(statuses, page=1, startdate=None, enddate=None):
     from standup.apps.status.models import Status
     if startdate:

--- a/standup/apps/status/models.py
+++ b/standup/apps/status/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime
-from standup.app import db
+
 from standup.apps.status.helpers import paginate
+from standup.main import db
+
 
 class Project(db.Model):
     """A project that does standups."""

--- a/standup/apps/status/views.py
+++ b/standup/apps/status/views.py
@@ -1,12 +1,15 @@
 from flask import (Blueprint, redirect, render_template, request, session,
                    url_for)
-from standup.app import db
-from standup.errors import forbidden, page_not_found
+
 from standup.apps.status.helpers import enddate, paginate, startdate
 from standup.apps.status.models import Project, Status
 from standup.apps.users.models import Team, User
+from standup.errors import forbidden, page_not_found
+from standup.main import db
+
 
 blueprint = Blueprint('status', __name__)
+
 
 @blueprint.route('/')
 def index():
@@ -19,6 +22,7 @@ def index():
             request.args.get('page', 1),
             startdate(request),
             enddate(request)),)
+
 
 @blueprint.route('/user/<slug>', methods=['GET'])
 def user(slug):
@@ -33,6 +37,7 @@ def user(slug):
             request.args.get('page', 1),
             startdate(request),
             enddate(request)))
+
 
 @blueprint.route('/project/<slug>', methods=['GET'])
 def project(slug):

--- a/standup/apps/users/models.py
+++ b/standup/apps/users/models.py
@@ -1,6 +1,7 @@
-from standup.app import db
 from standup.apps.status.models import Status
 from standup.apps.status.helpers import paginate
+from standup.main import db
+
 
 class Team(db.Model):
     """A team of users in the organization."""

--- a/standup/apps/users/views.py
+++ b/standup/apps/users/views.py
@@ -1,11 +1,14 @@
 import browserid
 from flask import Blueprint, jsonify, request, session
+
 from standup import settings
-from standup.utils import slugify
-from standup.app import db
 from standup.apps.users.models import User
+from standup.main import db
+from standup.utils import slugify
+
 
 blueprint = Blueprint('users', __name__)
+
 
 @blueprint.route('/authenticate', methods=['POST'])
 def authenticate():
@@ -32,6 +35,7 @@ def authenticate():
     response = jsonify({'email': user.email})
     response.status_code = 200
     return response
+
 
 @blueprint.route('/logout', methods=['POST'])
 def logout():

--- a/standup/errors.py
+++ b/standup/errors.py
@@ -1,5 +1,7 @@
 from flask import render_template, request
+
 from standup.utils import json_requested, jsonify
+
 
 def register_error_handlers(app):
     app.register_error_handler(403, forbidden)

--- a/standup/filters.py
+++ b/standup/filters.py
@@ -1,11 +1,15 @@
 import hashlib
 import re
-from bleach import clean
-from flask import url_for
-from standup import settings
 from urllib import urlencode
 
+from bleach import clean
+from flask import url_for
+
+from standup import settings
+
+
 TAG_TMPL = '{0} <span class="tag tag-{1}">{2}</span>'
+
 
 def register_filters(app):
     app.add_template_filter(dateformat)
@@ -51,20 +55,22 @@ def format_update(update, project=None):
     formatted = clean(update, tags=[])
 
     # Linkify "bug #n" and "bug n" text.
-    formatted = re.sub(r'(bug) #?(\d+)',
+    formatted = re.sub(
+        r'(bug) #?(\d+)',
         r'<a href="http://bugzilla.mozilla.org/show_bug.cgi?id=\2">\1 \2</a>',
         formatted, flags=re.I)
 
     # Linkify "pull #n" and "pull n" text.
     if project and project.repo_url:
-        formatted = re.sub(r'(pull|pr) #?(\d+)',
+        formatted = re.sub(
+            r'(pull|pr) #?(\d+)',
             r'<a href="%s/pull/\2">\1 \2</a>' % project.repo_url, formatted,
             flags=re.I)
 
     # Search for tags on the original, unformatted string. A tag must start
     # with a letter.
     tags = re.findall(r'(?:^|[^\w\\/])#([a-zA-Z][a-zA-Z0-9_\.-]*)(?:\b|$)',
-        update)
+                      update)
     tags.sort()
     if tags:
         tags_html = ''

--- a/standup/main.py
+++ b/standup/main.py
@@ -1,18 +1,23 @@
 import os
 from datetime import date, timedelta
+
 from flask import Flask, request, session
-from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.markdown import Markdown
+from flask.ext.sqlalchemy import SQLAlchemy
+
 from standup.errors import register_error_handlers
 from standup.filters import register_filters
 
+
 db = SQLAlchemy()
+
 
 def create_app(settings):
     app = Flask(__name__)
     app.debug = getattr(settings, 'DEBUG', False)
     app.config['SITE_TITLE'] = getattr(settings, 'SITE_TITLE', 'Standup')
-    app.config['SQLALCHEMY_DATABASE_URI'] = getattr(settings, 'DATABASE_URL',
+    app.config['SQLALCHEMY_DATABASE_URI'] = getattr(
+        settings, 'DATABASE_URL',
         os.environ.get('DATABASE_URL', 'sqlite:///standup_app.db'))
     app.secret_key = settings.SESSION_SECRET
     Markdown(app)
@@ -27,8 +32,9 @@ def create_app(settings):
 
     # Register blueprints
     for blueprint in settings.BLUEPRINTS:
-        app.register_blueprint(getattr(
-            __import__(blueprint, fromlist=['blueprint']), 'blueprint'))
+        app.register_blueprint(
+            getattr(
+                __import__(blueprint, fromlist=['blueprint']), 'blueprint'))
 
     @app.context_processor
     def inject_page():

--- a/standup/tests/__init__.py
+++ b/standup/tests/__init__.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from functools import wraps
 from standup import test_settings
-from standup.app import create_app, db
+from standup.main import create_app, db
 from standup.apps.status.models import Project, Status
 from standup.apps.users.models import User
 

--- a/standup/tests/test_app.py
+++ b/standup/tests/test_app.py
@@ -2,14 +2,16 @@ import json
 import os
 import tempfile
 import unittest
-from . import BaseTestCase
+
+
 from nose.tools import ok_, eq_
-from standup import app
+
+from standup import main
+from standup import settings
 from standup.apps.status.models import Project, Status
 from standup.apps.users.models import User
 from standup.filters import format_update, TAG_TMPL
-from standup import settings
-from standup.tests import status, user
+from standup.tests import BaseTestCase, status, user
 
 class KungFuActionGripProfileTestCase(BaseTestCase):
     def test_profile_unauthenticated(self):
@@ -63,8 +65,8 @@ class StatusizerTestCase(BaseTestCase):
         user(email='joe@example.com', save=True)
 
         p = Project(name='blackhole', slug='blackhole')
-        app.db.session.add(p)
-        app.db.session.commit()
+        main.db.session.add(p)
+        main.db.session.commit()
         pid = p.id
 
         with self.app.session_transaction() as sess:
@@ -99,8 +101,8 @@ class APITestCase(BaseTestCase):
     def test_format_update(self):
         p = Project(name='mdndev', slug='mdndev',
                     repo_url='https://github.com/mozilla/kuma')
-        app.db.session.add(p)
-        app.db.session.commit()
+        main.db.session.add(p)
+        main.db.session.commit()
         content = "#merge pull #1 and pR 2 to fix bug #3 and BUg 4"
         formatted_update = format_update(content, project=p)
         ok_('tag-merge' in formatted_update)
@@ -276,8 +278,8 @@ class APITestCase(BaseTestCase):
         self.assertEqual(u.name, 'Test')
 
     def test_update_user_by_admins(self):
-        """Test that an admin can update another users settings and non-admins
-        cannot update other users settings
+        """Test that an admin can update another users settings and
+        non-admins cannot update other users settings
         """
         u = user(save=True)
         a = user(username='admin', slug='admin', email='admin@mail.com',

--- a/standup/utils.py
+++ b/standup/utils.py
@@ -1,9 +1,12 @@
 import json
 import re
+
 from flask import Response, request
 from unidecode import unidecode
 
+
 _PUNCT_RE = re.compile(r'[\t !"#$%&\'()*\-/<=>?@\[\\\]^_`{|},.]+')
+
 
 def slugify(text, delim=u'-'):
     """Generates an ASCII-only slug."""

--- a/standup/wsgi.py
+++ b/standup/wsgi.py
@@ -1,4 +1,4 @@
 from standup import settings
-from standup.app import create_app
+from standup.main import create_app
 
 app = create_app(settings)


### PR DESCRIPTION
There are too many things named "app" so this changes the standup.app
module to "standup.main" which isn't a great name, but better than
having multiple app things.

This also does a code cleanup pass fixing end-of-line things,
organization of imports, ...

r?
