### PR TITLE
Fix week_end to return end-of-day

### DIFF
--- a/standup/apps/status/helpers.py
+++ b/standup/apps/status/helpers.py
@@ -59,9 +59,11 @@ def get_weeks(num_weeks=10):
 
 def week_start(d):
     """Weeks start on the Monday on or before the given date"""
-    return d - timedelta(d.isoweekday() - 1)
+    d = d - timedelta(d.isoweekday() - 1)
+    return datetime(d.year, d.month, d.day, 0, 0, 0)
 
 
 def week_end(d):
     """Weeks start on the Sunday on or after the given date"""
-    return d + timedelta(7 - d.isoweekday())
+    d = d + timedelta(7 - d.isoweekday())
+    return datetime(d.year, d.month, d.day, 23, 59, 59)

--- a/standup/tests/test_api2.py
+++ b/standup/tests/test_api2.py
@@ -308,12 +308,14 @@ class TimelinesMixin(object):
         """Test the week parameter of home_timeline"""
         year = 2014
         month = 5
-        day = 23
+        # May 18th, 2014 is a Sunday so it tests the week_end edge
+        # case.
+        day = 18
         date_str = "%04d-%02d-%02d" % (year, month, day)
         with self.app.app_context():
             u = user(save=True, team={})
             p = project(save=True)
-            d = datetime(year, month, day)
+            d = datetime(year, month, day, 12, 0)
             s = status(user=u, project=p, save=True, created=d)
 
         # A badly formatted date should raise ApiError (returning 400)

--- a/standup/tests/test_status.py
+++ b/standup/tests/test_status.py
@@ -40,7 +40,7 @@ class HelpersTestCase(BaseTestCase):
         eq_(enddate(req), datetime(2012, 5, 25))
 
         req = create_request(query_string={'week': '2012-05-24'})
-        eq_(enddate(req), datetime(2012, 5, 27))
+        eq_(enddate(req), datetime(2012, 5, 27, 23, 59, 59))
 
         req = create_request(query_string={'day': 'today'})
         eq_(enddate(req), None)
@@ -102,10 +102,8 @@ class HelpersTestCase(BaseTestCase):
     def test_weeks(self):
         """Test the week start/end helper functions."""
         d = datetime(2014, 1, 29)
-        start = week_start(d)
-        eq_(start, datetime(2014, 1, 27))
-        end = week_end(d)
-        eq_(end, datetime(2014, 2, 2))
+        eq_(week_start(d), datetime(2014, 1, 27, 0, 0, 0))
+        eq_(week_end(d), datetime(2014, 2, 2, 23, 59, 59))
 
 
 class ModelsTestCase(BaseTestCase):


### PR DESCRIPTION
This changes week_start and week_end so they explicitly return the
beginning and end of day respectively.

This fixes the problem where you ask for all the statuses in a given
week, but it's not returning the stuff on Sunday because it was doing
a <= of the beginning of Sunday rather than the end of Sunday.

r?
