### PR TITLE
Query a case-insensitive match for username

### DIFF
--- a/standup/apps/status/views.py
+++ b/standup/apps/status/views.py
@@ -94,7 +94,7 @@ def user(slug):
     """The user page. Shows a user's statuses."""
     db = get_session(current_app)
 
-    user = db.query(User).filter_by(slug=slug).first()
+    user = db.query(User).filter_by(slug__iexact=slug).first()
     if not user:
         return page_not_found('User not found.')
     return render_template(


### PR DESCRIPTION
Some persons username maybe in lower or upper case. This would fix the issue.
Like, there is user named "topal" But, trying to get profile "Topal" return user not found. But this can be avoid by a case-insensitive DB query.

r?