### PR TITLE
Fix #173: Use default staticfiles storage for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,27 @@ env:
     - HEROKU_PROD_APP=standups
     - HEROKU_STAGE_APP=standupstage
     - HEROKU_PROC_TYPE=web
+    - DOCKER_CACHE_FILE=/home/travis/docker/cache.tar.gz
+cache:
+  directories:
+    - /home/travis/docker/
 before_install:
   - docker -v
   - docker-compose -v
+  - echo "ENV GIT_SHA ${TRAVIS_COMMIT}" >> docker/standup_base
+  - bin/travis-docker-cache.sh load
 install: make build
-script: make test-image
-after_success: bin/deploy.sh
+script:
+  - make test-image
+  - bin/travis-docker-cache.sh save
+deploy:
+  - provider: script
+    script: bin/deploy.sh stage
+    on:
+      branch: master
+      repo: mozilla/standup
+  - provider: script
+    script: bin/deploy.sh prod
+    on:
+      tags: true
+      repo: mozilla/standup

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -3,13 +3,17 @@
 # NOTE Do **not** set -x here as that would expose sensitive credentials
 #      in the Travis build logs.
 
+# debugging info
+echo "TRAVIS_TAG=$TRAVIS_TAG"
+echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
+
 # tag has to be in the form "2016-08-30" (optionally with a ".1" after for same day deploys)
-if [[ "$TRAVIS_TAG" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9])?$ ]]; then
-  HEROKU_APP="$HEROKU_PROD_APP"
+if [[ "$1" == "prod" ]] && [[ "$TRAVIS_TAG" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9])?$ ]]; then
   # TODO enable this when we're really ready for prod
+  # HEROKU_APP="$HEROKU_PROD_APP"
   echo "Would have deployed to Prod on Heroku, but we're not ready yet."
   exit 0
-elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
+elif [[ "$1" == "stage" ]] && [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] && [[ "$TRAVIS_BRANCH" == "master" ]]; then
   HEROKU_APP="$HEROKU_STAGE_APP"
 else
   echo "Nothing to deploy"
@@ -17,6 +21,7 @@ else
 fi
 
 DOCKER_TAG="$DOCKER_REGISTRY/$HEROKU_APP/$HEROKU_PROC_TYPE"
-docker login -e "$HEROKU_EMAIL" -u "$HEROKU_EMAIL" -p "$HEROKU_API_KEY" "$DOCKER_REGISTRY"
+echo "Pushing $DOCKER_TAG"
+docker login -u "$HEROKU_EMAIL" -p "$HEROKU_API_KEY" "$DOCKER_REGISTRY"
 docker tag local/standup_base "$DOCKER_TAG"
 docker push "$DOCKER_TAG"

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -ex
 
-./bin/run-common.sh
-py.test
+export DATABASE_URL=sqlite:// SECRET_KEY=itsasekrit
+
+py.test $@

--- a/bin/travis-docker-cache.sh
+++ b/bin/travis-docker-cache.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+case "$1" in
+  save)
+    # Save built images to Travis cache directory
+    if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] && [[ "${TRAVIS_BRANCH}" == "master" ]]; then
+      mkdir -p $(dirname "${DOCKER_CACHE_FILE}")
+      docker save $(docker history -q local/standup_dev | grep -v '<missing>') | \
+             gzip > "${DOCKER_CACHE_FILE}"
+    fi
+    ;;
+  load)
+    if [[ -f "${DOCKER_CACHE_FILE}" ]]; then
+      gunzip -c "${DOCKER_CACHE_FILE}" | docker load
+    fi
+    ;;
+  *)
+    echo "Unknown action $1"
+esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,19 +39,11 @@ services:
     image: local/standup_dev
     volumes:
       - .:/app
-    environment:
-      - DATABASE_URL=sqlite://
-      - ALLOWED_HOSTS=localhost,127.0.0.1
-      - SECRET_KEY=itsasekrit
     command:
       ./bin/run-tests.sh
 
   # run the tests against the files in the image, not local
   test-image:
     image: local/standup_dev
-    environment:
-      - DATABASE_URL=sqlite://
-      - ALLOWED_HOSTS=localhost,127.0.0.1
-      - SECRET_KEY=itsasekrit
     command:
       ./bin/run-tests.sh

--- a/standup/settings.py
+++ b/standup/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 from everett.manager import ConfigManager, ConfigEnvFileEnv, ConfigOSEnv, ListOf
@@ -152,3 +153,7 @@ SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default='false', parser=bool
 STATIC_ROOT = path('staticfiles')
 STATIC_URL = '/static/'
 STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+
+if sys.argv[0].endswith('py.test'):
+    # won't barf if staticfiles are missing
+    STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'


### PR DESCRIPTION
It's actually the Gzip Manifest staticfiles storage that barfs if the files are missing. I think this is a fine fix for this (we also do this in bedrock) since I don't think static files should be required for python unittests, but I'm happy to hear a differing opinion.