### PR TITLE
More api

### DIFF
--- a/standup/api/tests/test_views.py
+++ b/standup/api/tests/test_views.py
@@ -5,8 +5,16 @@ from django.utils.encoding import force_bytes
 from django.test import Client, TestCase
 
 from standup.api.tests.factories import SystemTokenFactory
-from standup.status.models import Project, Status
-from standup.status.tests.factories import ProjectFactory, StatusFactory, StandupUserFactory
+from standup.status.models import (
+    Project,
+    Status,
+    StandupUser,
+)
+from standup.status.tests.factories import (
+    ProjectFactory,
+    StatusFactory,
+    StandupUserFactory,
+)
 
 
 def _content_generator():
@@ -45,6 +53,11 @@ class JSONClient(Client):
     def post_json(self, path, payload, secure=False, **extra):
         payload = force_bytes(json.dumps(payload))
         return self.generic('POST', path, payload, content_type='application/json',
+                            secure=secure, **extra)
+
+    def delete_json(self, path, payload, secure=False, **extra):
+        payload = force_bytes(json.dumps(payload))
+        return self.generic('DELETE', path, payload, content_type='application/json',
                             secure=secure, **extra)
 
 
@@ -232,3 +245,124 @@ class TestStatusPost(APITestCase):
         )
         assert resp.status_code == 403
         assert resp.content == b'{"error": "Api key forbidden."}'
+
+
+class TestStatusDelete(APITestCase):
+    def test_delete(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create()
+        status = StatusFactory.create(user=standupuser)
+
+        resp = self.client.delete_json(
+            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            payload={
+                'api_key': token.token,
+                'user': standupuser.username,
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.content == ('{"id": %s}' % (status.id,)).encode('utf-8')
+
+    def test_invalid_username(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create()
+        status = StatusFactory.create(user=standupuser)
+
+        resp = self.client.delete_json(
+            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            payload={
+                'api_key': token.token,
+                'user': ''
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.content == b'{"error": "Missing required fields."}'
+
+    def test_status_does_not_exist(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create()
+
+        resp = self.client.delete_json(
+            reverse('api-status-delete', kwargs={'pk': str(1000)}),
+            payload={
+                'api_key': token.token,
+                'user': standupuser.username,
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.content == b'{"error": "Status does not exist."}'
+
+    def test_wrong_user(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create(user__username='charlie')
+        status = StatusFactory.create(user=standupuser)
+
+        resp = self.client.delete_json(
+            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            payload={
+                'api_key': token.token,
+                'user': 'fred',
+            }
+        )
+        assert resp.status_code == 403
+        assert resp.content == b'{"error": "You cannot delete this status."}'
+
+
+class TestUpdateUser(APITestCase):
+    def test_update_name(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create(name='Data')
+
+        resp = self.client.post_json(
+            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            payload={
+                'api_key': token.token,
+                'name': 'Lor',
+            }
+        )
+        assert resp.status_code == 200
+        standupuser = StandupUser.objects.get(pk=standupuser.id)
+        assert standupuser.name == 'Lor'
+
+    def test_update_email(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create(email='data@example.com')
+
+        resp = self.client.post_json(
+            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            payload={
+                'api_key': token.token,
+                'email': 'lor@example.com',
+            }
+        )
+        assert resp.status_code == 200
+        standupuser = StandupUser.objects.get(pk=standupuser.id)
+        assert standupuser.email == 'lor@example.com'
+
+    def test_update_github_handle(self):
+        token = SystemTokenFactory.create()
+        standupuser = StandupUserFactory.create(github_handle='data')
+
+        resp = self.client.post_json(
+            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            payload={
+                'api_key': token.token,
+                'github_handle': 'lor',
+            }
+        )
+        assert resp.status_code == 200
+        standupuser = StandupUser.objects.get(pk=standupuser.id)
+        assert standupuser.github_handle == 'lor'
+
+    def test_user_does_not_exist(self):
+        token = SystemTokenFactory.create()
+
+        resp = self.client.post_json(
+            reverse('api-update-user', kwargs={'username': 'cmdrdata'}),
+            payload={
+                'api_key': token.token,
+                'name': 'lor',
+            }
+        )
+        assert resp.status_code == 400
+        assert resp.content == b'{"error": "User does not exist."}'

--- a/standup/api/tests/test_views.py
+++ b/standup/api/tests/test_views.py
@@ -70,7 +70,7 @@ class TestAPIView(APITestCase):
     """Tests the APIView using the StatusPost view"""
     def test_get_fails(self):
         """Verify GET fails because it's not an allowed method"""
-        resp = self.client.get(reverse('api-status-post'))
+        resp = self.client.get(reverse('api.status-create'))
         assert resp.status_code == 405
         assert resp['content_type'] == 'application/json'
         assert resp.content == b'{"error": "Method not allowed"}'
@@ -84,7 +84,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -102,7 +102,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -124,7 +124,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -144,7 +144,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -164,7 +164,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -184,7 +184,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -204,7 +204,7 @@ class TestStatusPost(APITestCase):
 
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': token.token,
                 'user': standupuser.user.username,
@@ -223,7 +223,7 @@ class TestStatusPost(APITestCase):
         """Verify POST with no auth fails"""
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'user': 'jcoulton',
                 'content': content
@@ -236,7 +236,7 @@ class TestStatusPost(APITestCase):
         """Verify POST fails with wrong auth token"""
         content = next(content_generator)
         resp = self.client.post_json(
-            reverse('api-status-post'),
+            reverse('api.status-create'),
             payload={
                 'api_key': 'ou812',
                 'user': 'jcoulton',
@@ -254,7 +254,7 @@ class TestStatusDelete(APITestCase):
         status = StatusFactory.create(user=standupuser)
 
         resp = self.client.delete_json(
-            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            reverse('api.status-delete', kwargs={'pk': str(status.id)}),
             payload={
                 'api_key': token.token,
                 'user': standupuser.username,
@@ -269,7 +269,7 @@ class TestStatusDelete(APITestCase):
         status = StatusFactory.create(user=standupuser)
 
         resp = self.client.delete_json(
-            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            reverse('api.status-delete', kwargs={'pk': str(status.id)}),
             payload={
                 'api_key': token.token,
                 'user': ''
@@ -283,7 +283,7 @@ class TestStatusDelete(APITestCase):
         standupuser = StandupUserFactory.create()
 
         resp = self.client.delete_json(
-            reverse('api-status-delete', kwargs={'pk': str(1000)}),
+            reverse('api.status-delete', kwargs={'pk': str(1000)}),
             payload={
                 'api_key': token.token,
                 'user': standupuser.username,
@@ -298,7 +298,7 @@ class TestStatusDelete(APITestCase):
         status = StatusFactory.create(user=standupuser)
 
         resp = self.client.delete_json(
-            reverse('api-status-delete', kwargs={'pk': str(status.id)}),
+            reverse('api.status-delete', kwargs={'pk': str(status.id)}),
             payload={
                 'api_key': token.token,
                 'user': 'fred',
@@ -314,7 +314,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(name='Data')
 
         resp = self.client.post_json(
-            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.username}),
             payload={
                 'api_key': token.token,
                 'name': 'Lor',
@@ -329,7 +329,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(email='data@example.com')
 
         resp = self.client.post_json(
-            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.username}),
             payload={
                 'api_key': token.token,
                 'email': 'lor@example.com',
@@ -344,7 +344,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(github_handle='data')
 
         resp = self.client.post_json(
-            reverse('api-update-user', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.username}),
             payload={
                 'api_key': token.token,
                 'github_handle': 'lor',
@@ -358,7 +358,7 @@ class TestUpdateUser(APITestCase):
         token = SystemTokenFactory.create()
 
         resp = self.client.post_json(
-            reverse('api-update-user', kwargs={'username': 'cmdrdata'}),
+            reverse('api.user-update', kwargs={'username': 'cmdrdata'}),
             payload={
                 'api_key': token.token,
                 'name': 'lor',

--- a/standup/api/urls.py
+++ b/standup/api/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^v1/status/(?P<pk>\d{1,8})/$', views.StatusDelete.as_view(), name='api-status-delete'),
-    url(r'^v1/status/', views.StatusPost.as_view(), name='api-status-post'),
-    url(r'^v1/user/(?P<username>[a-zA-Z0-9]+)/$', views.UpdateUser.as_view(), name='api-update-user'),
+    url(r'^v1/status/(?P<pk>\d{1,8})/$', views.StatusDelete.as_view(), name='api.status-delete'),
+    url(r'^v1/status/', views.StatusCreate.as_view(), name='api.status-create'),
+    url(r'^v1/user/(?P<username>[a-zA-Z0-9]+)/$', views.UpdateUser.as_view(), name='api.user-update'),
 ]

--- a/standup/api/urls.py
+++ b/standup/api/urls.py
@@ -4,5 +4,7 @@ from . import views
 
 
 urlpatterns = [
-    url(r'^v1/status/', views.StatusPost.as_view(), name='api-status-post')
+    url(r'^v1/status/(?P<pk>\d{1,8})/$', views.StatusDelete.as_view(), name='api-status-delete'),
+    url(r'^v1/status/', views.StatusPost.as_view(), name='api-status-post'),
+    url(r'^v1/user/(?P<username>[a-zA-Z0-9]+)/$', views.UpdateUser.as_view(), name='api-update-user'),
 ]

--- a/standup/api/views.py
+++ b/standup/api/views.py
@@ -140,7 +140,7 @@ class AuthenticatedAPIView(APIView):
         request.auth_token = token
 
 
-class StatusPost(AuthenticatedAPIView):
+class StatusCreate(AuthenticatedAPIView):
     def post(self, request):
         token = request.auth_token
 

--- a/standup/api/views.py
+++ b/standup/api/views.py
@@ -155,7 +155,7 @@ class StatusPost(AuthenticatedAPIView):
 
         # Validate we have the required fields.
         if not (username and content):
-            return HttpResponseBadRequest('Missing required fields')
+            return HttpResponseBadRequest('Missing required fields.')
 
         # If this is a reply make sure that the status being replied to
         # exists and is not itself a reply
@@ -190,3 +190,50 @@ class StatusPost(AuthenticatedAPIView):
         status.save()
 
         return HttpResponseJSON({'id': status.id, 'content': content})
+
+
+class StatusDelete(AuthenticatedAPIView):
+    def delete(self, request, pk):
+        token = request.auth_token
+
+        # FIXME: Authorize this operation.
+
+        username = request.json_body.get('user')
+
+        if not username:
+            return HttpResponseBadRequest('Missing required fields.')
+
+        status = Status.objects.filter(id=pk).first()
+        if not status:
+            return HttpResponseBadRequest('Status does not exist.')
+
+        if status.user.username != username:
+            return HttpResponseForbidden('You cannot delete this status.')
+
+        status_id = status.id
+        status.delete()
+
+        return HttpResponseJSON({'id': status_id})
+
+
+class UpdateUser(AuthenticatedAPIView):
+    def post(self, request, username):
+        token = request.auth_token
+
+        # FIXME: Authorize this operation.
+
+        user = StandupUser.objects.filter(user__username=username).first()
+        if not user:
+            return HttpResponseBadRequest('User does not exist.')
+
+        if 'name' in request.json_body:
+            user.name = request.json_body['name']
+        if 'email' in request.json_body:
+            user.user.email = request.json_body['email']
+        if 'github_handle' in request.json_body:
+            user.github_handle = request.json_body['github_handle']
+
+        user.save()
+        user.user.save()
+
+        return HttpResponseJSON({'id': user.id})


### PR DESCRIPTION
This implements the remaining required API endpoints that we need for the standup-irc bot.

Two caveats:

1. I didn't implement the ability for admin to change user settings via the api--they should do that in the webapp.
2. I didn't implement any of the team management stuff which is /api/v2 endpoints that are all pretty different. I wrote some notes on that, but I kind of think we should do that in the webapp, too. Maybe later we can implement a new api for it or something.

Thoughts? r?