### PR TITLE
Add XFrameOptionsMiddleware (see #224)

### DIFF
--- a/standup/settings.py
+++ b/standup/settings.py
@@ -60,6 +60,7 @@ MIDDLEWARE_CLASSES = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'standup.status.middleware.NewUserProfileMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',    
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/standup/settings.py
+++ b/standup/settings.py
@@ -60,7 +60,7 @@ MIDDLEWARE_CLASSES = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'standup.status.middleware.NewUserProfileMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',    
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
This sets the X-Frame-Options header to SAMEORIGIN for every outgoing HttpResponse according to the [django docs](https://docs.djangoproject.com/en/1.9/ref/clickjacking/#how-to-use-it)