### PR TITLE
This should add the X-Content-Type: nosniff header

### DIFF
--- a/standup/settings.py
+++ b/standup/settings.py
@@ -144,7 +144,7 @@ USE_L10N = True
 USE_TZ = True
 
 # security
-
+SECURE_CONTENT_TYPE_NOSNIFF = config('SECURE_CONTENT_TYPE_NOSNIFF', default='true', parser=bool)
 SECURE_BROWSER_XSS_FILTER = config('SECURE_BROWSER_XSS_FILTER', default='true', parser=bool)
 # this should be 31536000 in prod (1 year)
 SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default='0', parser=int)


### PR DESCRIPTION
On a side-note, all configs default to either 'true' or 'false', which I found _slightly_ confusing.

I suppose 'True' and 'False' (still quoted, by uppercase) would be a bit more pythonic. 

I'll file another PR should we care enough to change this (cc @pmac to decide this :))