### PR TITLE
Switch JS and CSS compressors

### DIFF
--- a/docker/standup_base
+++ b/docker/standup_base
@@ -7,7 +7,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV LANG=C.UTF-8
 ENV PATH=/usr/local/lib/node_modules/standup/node_modules/.bin:$PATH
 ENV PIPELINE_LESS_BINARY=lessc
-ENV PIPELINE_YUGLIFY_BINARY=yuglify
+ENV PIPELINE_UGLIFYJS_BINARY=uglifyjs
+ENV PIPELINE_CLEANCSS_BINARY=cleancss
 
 # Project settings
 ENV DJANGO_SETTINGS_MODULE standup.settings

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "homepage": "https://github.com/mozilla/standup#readme",
   "dependencies": {
+    "clean-css": "3.4.19",
     "less": "2.7.1",
-    "yuglify": "0.1.4"
+    "uglify-js": "2.7.3"
   }
 }

--- a/standup/pipeline.py
+++ b/standup/pipeline.py
@@ -1,0 +1,7 @@
+from pipeline.conf import settings
+from pipeline.compressors import SubProcessCompressor
+
+
+class CleanCSSCompressor(SubProcessCompressor):
+    def compress_css(self, css):
+        return self.execute_command([settings.CLEANCSS_BINARY], css)

--- a/standup/settings.py
+++ b/standup/settings.py
@@ -268,10 +268,12 @@ PIPELINE = {
     'LESS_BINARY': config('PIPELINE_LESS_BINARY',
                           default=path('node_modules', '.bin', 'lessc')),
     # 'LESS_ARGUMENTS': config('PIPELINE_LESS_ARGUMENTS', default='-s'),
-    'JS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
-    'CSS_COMPRESSOR': 'pipeline.compressors.yuglify.YuglifyCompressor',
-    'YUGLIFY_BINARY': config('PIPELINE_YUGLIFY_BINARY',
-                             default=path('node_modules', '.bin', 'yuglify')),
+    'JS_COMPRESSOR': 'pipeline.compressors.uglifyjs.UglifyJSCompressor',
+    'CSS_COMPRESSOR': 'standup.pipeline.CleanCSSCompressor',
+    'CLEANCSS_BINARY': config('PIPELINE_CLEANCSS_BINARY',
+                              default=path('node_modules', '.bin', 'cleancss')),
+    'UGLIFYJS_BINARY': config('PIPELINE_UGLIFYJS_BINARY',
+                              default=path('node_modules', '.bin', 'uglifyjs')),
 }
 
 RAVEN_CONFIG = {


### PR DESCRIPTION
Switching from the seemingly abandoned yuglify to:

* [clean-css](https://www.npmjs.com/package/clean-css)
* [uglify-js](https://www.npmjs.com/package/uglify-js)

This is what MDN is currently using and what bedrock is likely switching to shortly.