### PR TITLE
Add middleware to enforce a hostname of our choice

### DIFF
--- a/standup/settings.py
+++ b/standup/settings.py
@@ -31,6 +31,7 @@ SECRET_KEY = config('SECRET_KEY')
 DEBUG = config('DEBUG', default='false', parser=bool)
 
 ALLOWED_HOSTS = config('ALLOWED_HOSTS', parser=ListOf(str), default='localhost')
+ENFORCE_HOSTNAME = config('ENFORCE_HOSTNAME', parser=ListOf(str), raise_error=False)
 SITE_TITLE = config('SITE_TITLE', default='Standup')
 
 # Application definition
@@ -58,6 +59,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
+    'standup.status.middleware.EnforceHostnameMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'standup.status.middleware.NewUserProfileMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/standup/status/middleware.py
+++ b/standup/status/middleware.py
@@ -1,4 +1,5 @@
-from django.http import HttpResponseRedirect
+from django.conf import settings
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 
 
 class NewUserProfileMiddleware(object):
@@ -9,3 +10,34 @@ class NewUserProfileMiddleware(object):
             return HttpResponseRedirect('/new-profile/')
 
         return response
+
+
+class EnforceHostnameMiddleware(object):
+    """
+    Enforce the hostname per the ENFORCE_HOSTNAME setting in the project's settings
+
+    The ENFORCE_HOSTNAME can either be a single host or a list of acceptable hosts
+
+    via http://www.michaelvdw.nl/code/force-hostname-with-django-middleware-for-heroku/
+    """
+    def process_request(self, request):
+        """Enforce the host name"""
+        allowed_hosts = getattr(settings, 'ENFORCE_HOSTNAME', None)
+
+        if settings.DEBUG or not allowed_hosts:
+            return None
+
+        host = request.get_host()
+
+        # find the allowed host name(s)
+        if isinstance(allowed_hosts, str):
+            allowed_hosts = [allowed_hosts]
+        if host in allowed_hosts:
+            return None
+
+        # redirect to the proper host name\
+        new_url = "%s://%s%s" % (
+            'https' if request.is_secure() else 'http',
+            allowed_hosts[0], request.get_full_path())
+
+        return HttpResponsePermanentRedirect(new_url)


### PR DESCRIPTION
e.g. requests to https://standups.herokuapp.com would redirect to https://www.standu.ps if we set ENFORCE_HOSTNAME=www.standu.ps.