### PR TITLE
Fix error pages not having context-processor data

### DIFF
--- a/standup/settings.py
+++ b/standup/settings.py
@@ -124,6 +124,7 @@ TEMPLATES = [
         },
     },
 ]
+DEFAULT_JINJA2_TEMPLATE_EXTENSION = '.html'
 
 WSGI_APPLICATION = 'standup.wsgi.application'
 

--- a/standup/urls.py
+++ b/standup/urls.py
@@ -1,21 +1,15 @@
-"""standup URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/1.8/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
-Including another URLconf
-    1. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
-"""
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth.views import logout
 
+from django_jinja import views
+
+
+# these will include context processors
+handler400 = views.BadRequest.as_view()
+handler403 = views.PermissionDenied.as_view()
+handler404 = views.PageNotFound.as_view()
+handler500 = views.ServerError.as_view()
 
 urlpatterns = [
     url(r'^api/', include('standup.api.urls')),


### PR DESCRIPTION
This should fix this issue. The error views included with django-jinja use normal view context instances.