### PR TITLE
Individual status page 404 instead of 500

### DIFF
--- a/standup/status/tests/test_views.py
+++ b/standup/status/tests/test_views.py
@@ -18,3 +18,7 @@ class HomeViewTestCase(TestCase):
         # FIXME: Need a better assertion here. Should probably assert that 5
         # statuses got rendered.
         self.assertNotContains(resp, 'No status updates available')
+
+    def test_status_404(self):
+        resp = self.client.get(reverse('status.status', kwargs={'pk': 1234}))
+        assert resp.status_code == 404

--- a/standup/status/views.py
+++ b/standup/status/views.py
@@ -6,6 +6,7 @@ from django.contrib import messages
 from django.contrib.syndication.views import Feed
 from django.core.paginator import Paginator, PageNotAnInteger, EmptyPage
 from django.core.urlresolvers import reverse
+from django.http import Http404
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, HttpResponseRedirect)
 from django.utils.feedgenerator import Atom1Feed
@@ -86,7 +87,11 @@ class StatusView(PaginateStatusesMixin, TemplateView):
     template_name = 'status/status.html'
 
     def get_status_queryset(self):
-        return Status.objects.filter(pk=self.kwargs['pk'])
+        qs = Status.objects.filter(pk=self.kwargs['pk'])
+        if not qs:
+            raise Http404()
+
+        return qs
 
 
 class UserView(PaginateStatusesMixin, DetailView):


### PR DESCRIPTION
View for an individual status was throwing an error from the paginator when the queryset was empty. This change forces the 404.

Note: We have to use the paginator even for this page because of what the macros that display statuses expect.