### PR TITLE
Irc nicks

### DIFF
--- a/standup/api/tests/test_views.py
+++ b/standup/api/tests/test_views.py
@@ -87,7 +87,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'content': content
             }
         )
@@ -105,7 +105,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'project': 'jcoulton',
                 'content': content
             }
@@ -127,7 +127,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'project': project.slug,
                 'content': content
             }
@@ -147,7 +147,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'reply_to': status.id,
                 'content': content
             }
@@ -167,7 +167,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'reply_to': 1000,
                 'content': content
             }
@@ -187,7 +187,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'reply_to': reply.id,
                 'content': content
             }
@@ -207,7 +207,7 @@ class TestStatusPost(APITestCase):
             reverse('api.status-create'),
             payload={
                 'api_key': token.token,
-                'user': standupuser.user.username,
+                'user': standupuser.irc_nick,
                 'reply_to': status.id,
                 'project': project.id,
                 'content': content
@@ -257,7 +257,7 @@ class TestStatusDelete(APITestCase):
             reverse('api.status-delete', kwargs={'pk': str(status.id)}),
             payload={
                 'api_key': token.token,
-                'user': standupuser.username,
+                'user': standupuser.irc_nick,
             }
         )
         assert resp.status_code == 200
@@ -286,7 +286,7 @@ class TestStatusDelete(APITestCase):
             reverse('api.status-delete', kwargs={'pk': str(1000)}),
             payload={
                 'api_key': token.token,
-                'user': standupuser.username,
+                'user': standupuser.irc_nick,
             }
         )
         assert resp.status_code == 400
@@ -314,7 +314,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(name='Data')
 
         resp = self.client.post_json(
-            reverse('api.user-update', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.irc_nick}),
             payload={
                 'api_key': token.token,
                 'name': 'Lor',
@@ -329,7 +329,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(email='data@example.com')
 
         resp = self.client.post_json(
-            reverse('api.user-update', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.irc_nick}),
             payload={
                 'api_key': token.token,
                 'email': 'lor@example.com',
@@ -344,7 +344,7 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUserFactory.create(github_handle='data')
 
         resp = self.client.post_json(
-            reverse('api.user-update', kwargs={'username': standupuser.username}),
+            reverse('api.user-update', kwargs={'username': standupuser.irc_nick}),
             payload={
                 'api_key': token.token,
                 'github_handle': 'lor',

--- a/standup/api/views.py
+++ b/standup/api/views.py
@@ -91,7 +91,7 @@ class APIView(View):
         """Dispatches like View, except always returns JSON responses"""
         try:
             if request.body:
-                # FIXME: This assumes the body is utf-8.
+                # FIXME(willkg): This assumes the body is utf-8.
                 request.json_body = json.loads(force_str(request.body))
                 if not isinstance(request.json_body, dict):
                     raise Exception('Unrecognized JSON payload.')
@@ -144,9 +144,10 @@ class StatusCreate(AuthenticatedAPIView):
     def post(self, request):
         # token = request.auth_token
 
-        # FIXME: Authorize operation.
+        # FIXME(willkg): Authorize operation.
 
-        username = request.json_body.get('user')
+        # FIXME(willkg): This makes the API irc-specific.
+        irc_nick = request.json_body.get('user')
         project_slug = request.json_body.get('project')
         content = request.json_body.get('content')
         reply_to = request.json_body.get('reply_to')
@@ -154,7 +155,7 @@ class StatusCreate(AuthenticatedAPIView):
         replied = None
 
         # Validate we have the required fields.
-        if not (username and content):
+        if not (irc_nick and content):
             return HttpResponseBadRequest('Missing required fields.')
 
         # If this is a reply make sure that the status being replied to
@@ -167,7 +168,7 @@ class StatusCreate(AuthenticatedAPIView):
                 return HttpResponseBadRequest('Cannot reply to a reply.')
 
         # Get the user
-        user = StandupUser.objects.filter(user__username=username).first()
+        user = StandupUser.objects.filter(irc_nick=irc_nick).first()
         if not user:
             return HttpResponseBadRequest('User does not exist.')
 
@@ -196,18 +197,19 @@ class StatusDelete(AuthenticatedAPIView):
     def delete(self, request, pk):
         # token = request.auth_token
 
-        # FIXME: Authorize this operation.
+        # FIXME(willkg): Authorize this operation.
 
-        username = request.json_body.get('user')
+        # FIXME(willkg): This makes the API irc-specific.
+        irc_nick = request.json_body.get('user')
 
-        if not username:
+        if not irc_nick:
             return HttpResponseBadRequest('Missing required fields.')
 
         status = Status.objects.filter(id=pk).first()
         if not status:
             return HttpResponseBadRequest('Status does not exist.')
 
-        if status.user.username != username:
+        if status.user.irc_nick != irc_nick:
             return HttpResponseForbidden('You cannot delete this status.')
 
         status_id = status.id
@@ -220,9 +222,10 @@ class UpdateUser(AuthenticatedAPIView):
     def post(self, request, username):
         # token = request.auth_token
 
-        # FIXME: Authorize this operation.
+        # FIXME(willkg): Authorize this operation.
 
-        user = StandupUser.objects.filter(user__username=username).first()
+        # FIXME(willkg): This makes the API irc-specific.
+        user = StandupUser.objects.filter(irc_nick=username).first()
         if not user:
             return HttpResponseBadRequest('User does not exist.')
 

--- a/standup/status/forms.py
+++ b/standup/status/forms.py
@@ -16,8 +16,8 @@ class StatusizeForm(forms.ModelForm):
 class ProfileForm(forms.ModelForm):
     class Meta:
         model = StandupUser
-        fields = ['name', 'slug', 'github_handle']
+        fields = ['name', 'irc_nick', 'github_handle']
         labels = {
-            'slug': 'IRC Handle',
+            'irc_nick': 'IRC Handle',
             'github_handle': 'Github Handle',
         }

--- a/standup/status/migrations/0006_add_irc_nick.py
+++ b/standup/status/migrations/0006_add_irc_nick.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0005_add_team_user_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='standupuser',
+            name='irc_nick',
+            field=models.CharField(help_text='IRC nick for this particular user', max_length=100, null=True, unique=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='standupuser',
+            name='github_handle',
+            field=models.CharField(max_length=100, null=True, unique=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='standupuser',
+            name='slug',
+            field=models.SlugField(max_length=100, null=True, unique=True, blank=True),
+        ),
+    ]

--- a/standup/status/migrations/0006_add_irc_nick.py
+++ b/standup/status/migrations/0006_add_irc_nick.py
@@ -14,7 +14,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='standupuser',
             name='irc_nick',
-            field=models.CharField(help_text='IRC nick for this particular user', max_length=100, null=True, unique=True, blank=True),
+            field=models.CharField(help_text='IRC nick for this particular user',
+                                   max_length=100, null=True, unique=True, blank=True),
         ),
         migrations.AlterField(
             model_name='standupuser',

--- a/standup/status/migrations/0007_migration_irc_nick.py
+++ b/standup/status/migrations/0007_migration_irc_nick.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def migrate_irc_nick(apps, schema_editor):
+    """Copy the User.username into the StandupUser.irc_nick field because this is what the irc bot in
+    Standup v1 used to match.
+
+    """
+    StandupUser = apps.get_model('status', 'StandupUser')
+    for suser in StandupUser.objects.all():
+        suser.irc_nick = suser.user.username
+        suser.save()
+
+
+def wipe_irc_nick(apps, schema_editor):
+    """Wipe the StandupUser.irc_nick field contents"""
+    StandupUser = apps.get_model('status', 'StandupUser')
+    for suser in StandupUser.objects.all():
+        suser.irc_nick = None
+        suser.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0006_add_irc_nick'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_irc_nick, wipe_irc_nick),
+    ]

--- a/standup/status/models.py
+++ b/standup/status/models.py
@@ -74,6 +74,10 @@ class StandupUser(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='profile')
     name = models.CharField(max_length=100, blank=True, null=True)
     slug = models.SlugField(max_length=100, blank=True, null=True, unique=True)
+    irc_nick = models.CharField(
+        max_length=100, blank=True, null=True, unique=True,
+        help_text='IRC nick for this particular user'
+    )
     github_handle = models.CharField(max_length=100, blank=True, null=True, unique=True)
     teams = models.ManyToManyField(Team, related_name='users', through='TeamUser')
 
@@ -105,9 +109,9 @@ class StandupUser(models.Model):
         """Returns an OrderedDict of model attributes"""
         data = OrderedDict()
         data['id'] = self.id
-        data['username'] = self.username
         data['name'] = self.name
         data['slug'] = self.slug
+        data['irc_nick'] = self.irc_nick
         # FIXME: Should we be providing email addresses publicly via the api?
         # data['email'] = self.user.email
         data['github_handle'] = self.github_handle

--- a/standup/status/tests/factories.py
+++ b/standup/status/tests/factories.py
@@ -47,6 +47,7 @@ class StandupUserFactory(factory.django.DjangoModelFactory):
 
     user = factory.SubFactory(UserFactory)
     slug = factory.LazyAttribute(lambda obj: slugify(obj.user.username))
+    irc_nick = factory.Faker('user_name')
     github_handle = factory.LazyAttribute(lambda obj: obj.user.username)
     # FIXME: teams
 


### PR DESCRIPTION
This fixes the view and API code to use a new field `Standup.irc_nick` for matching IRC users to Standup users.

This is a short-term stopgap solution. It has a few problems:

1. the API now uses IRC nicks, but it shouldn't be IRC-centric
2. the user has to create their account, then fill in the IRC nick they're using before things work
3. it continues to only supports one IRC network

Despite that, this should go out soon because it's probably causing problems especially for new users.