### PR TITLE
Tweak cache settings for better memory usage

### DIFF
--- a/standup/settings.py
+++ b/standup/settings.py
@@ -147,6 +147,11 @@ CACHES = {
                       parser=django_cache_url.parse,
                       default='locmem:default')
 }
+if CACHES['default'].get('BACKEND', '') == 'django.core.cache.backends.locmem.LocMemCache':
+    # If we're using locmem, set timeout for 60 seconds and restrict
+    # cache to 100 things so as to not run rampant with memory usage.
+    CACHES['default']['timeout'] = 60
+    CACHES['default'].setdefault('OPTIONS', {})['MAX_ENTRIES'] = 100
 CACHE_MIDDLEWARE_SECONDS = config('CACHE_MIDDLEWARE_SECONDS', default='30', parser=int)
 CACHE_FEEDS_SECONDS = config('CACHE_FEEDS_SECONDS', default='1800', parser=int)  # 30 min
 


### PR DESCRIPTION
We're running out of memory in prod constantly. My current theory is
that our cache settings are such that we're using an increasing amount
of cache until we pass the threshold for memory allowance.

Assuming that's correct, limiting the caching by number of entries and
timeout should make that better.

This implements that.