### PR TITLE
Add rough statistics page

### DIFF
--- a/standup/status/jinja2/status/statistics.html
+++ b/standup/status/jinja2/status/statistics.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="grid_12">
+  <h1>Statistics</h1>
+  {% for groupname, groupitems in statsitems.items() %}
+  <h2>{{ groupname }}</h2>
+    <table class="stats">
+      {% for key, val in groupitems.items() %}
+      <tr>
+        <td class="key">{{ key }}</td>
+        <td class="val">{{ val }}</td>
+      </tr>
+      {% endfor %}
+    </table>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/standup/status/static/less/style.less
+++ b/standup/status/static/less/style.less
@@ -70,6 +70,19 @@ dl {
   }
 }
 
+table.stats {
+    tr {
+        td.key {
+            width: 15em;
+            font-weight: bold;
+            background: #bbb;
+        }
+        td.val {
+            padding-left: 1em;
+        }
+    }
+}
+
 footer {
   background: #fff;
   bottom: 0;

--- a/standup/status/tests/test_views.py
+++ b/standup/status/tests/test_views.py
@@ -42,3 +42,9 @@ class RobotsViewTestCase(TestCase):
         assert resp.status_code == 200
         assert resp['content-type'] == 'text/plain'
         assert resp.content == b'User-agent: *\nDisallow: /'
+
+
+class StatisticsViewTestCase(TestCase):
+    def test_statistics(self):
+        resp = self.client.get(reverse('status.statistics'))
+        assert resp.status_code == 200

--- a/standup/status/urls.py
+++ b/standup/status/urls.py
@@ -26,8 +26,10 @@ urlpatterns = [
     url(r'^team/{}.xml$'.format(SLUG_RE), cache_feed(views.TeamFeed()), name='status.team_feed'),
     url(r'^project/{}.xml$'.format(SLUG_RE), cache_feed(views.ProjectFeed()),
         name='status.project_feed'),
+    url(r'^statistics/$', views.statistics, name='status.statistics'),
     # csp
     url(r'^csp-violation-capture$', views.csp_violation_capture),
+    # robots
     url(r'^robots\.txt$', views.robots_txt),
 ]
 

--- a/standup/status/views.py
+++ b/standup/status/views.py
@@ -1,3 +1,6 @@
+import collections
+import datetime
+import gc
 import json
 import logging
 
@@ -9,6 +12,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, HttpResponseRedirect)
+from django.shortcuts import render_to_response
 from django.utils.feedgenerator import Atom1Feed
 from django.views.decorators.cache import cache_page
 from django.views.decorators.csrf import csrf_exempt
@@ -233,6 +237,9 @@ class TeamFeed(StatusesFeed):
         return obj.statuses().select_related('project', 'user')[:self.feed_limit]
 
 
+# RANDOM STUFF
+
+
 @csrf_exempt
 @require_POST
 def csp_violation_capture(request):
@@ -278,3 +285,36 @@ def errormenow(request):
     # This is an intentional error designed to kick up the error page because otherwise it's
     # difficult to test.
     1 / 0  # noqa
+
+
+def statistics(request):
+    """Show health statistics for the system"""
+    hours_24 = datetime.datetime.now() - datetime.timedelta(hours=24)
+    week = datetime.datetime.now() - datetime.timedelta(days=7)
+
+    groups = collections.OrderedDict()
+
+    groups['Standup users'] = collections.OrderedDict([
+        ('Team count', Team.objects.count()),
+        ('User count', StandupUser.objects.count()),
+        ('New users in last 24 hours', StandupUser.objects.filter(user__date_joined__gte=hours_24).count()),
+        ('Active users (posted in last week)',
+         StandupUser.objects.filter(id__in=Status.objects.filter(created__gte=week).values('user__id')).count()),
+
+    ])
+
+    groups['Standup status'] = collections.OrderedDict([
+        ('Status count', Status.objects.count()),
+        ('Status in last 24 hours', Status.objects.filter(created__gte=hours_24).count()),
+        ('Status in last week', Status.objects.filter(created__gte=week).count()),
+    ])
+
+    groups['Infra'] = collections.OrderedDict([
+        ('Objects count', len(gc.get_objects())),
+    ])
+
+    return render_to_response('status/statistics.html', {
+        'statsitems': groups,
+        'user': request.user,
+        'settings': settings,
+    })


### PR DESCRIPTION
This is a rough statistics page that shows a snapshot of Standup stuff.
It's rough in that it's not very pretty and it's not wildly informative.
But we can use this to build a better page that's more helpful.

This has some of the things in #267, but not everything. Regardless, I think I'm going to say this fixes #267 and we can add additional statistics as we have requirements for them.