### PR TITLE
Fix markdown call

### DIFF
--- a/standup/status/models.py
+++ b/standup/status/models.py
@@ -254,7 +254,8 @@ class Status(models.Model):
             formatted = PULL_RE.sub(
                 r'<a href="%s/pull/\2">\1 \2</a>' % self.project.repo_url, formatted)
 
-        return Markup(MD.convert(formatted))
+        formatted = MD.reset().convert(formatted)
+        return Markup(formatted)
 
     def dictify(self):
         """Returns an OrderedDict of model attributes"""


### PR DESCRIPTION
We use the same Markdown instance for all convert calls. Per the
Markdown docs, we need to call .reset() between convert calls so as to
reset the Markdown converter state and thus avoid performance
degredation over time.

https://pythonhosted.org/Markdown/reference.html#Markdown

This does that.

This also has a HUGE effect on memory and response time performance.