### PR TITLE
Remove Standup v2 announcement notice

### DIFF
--- a/standup/status/jinja2/base.html
+++ b/standup/status/jinja2/base.html
@@ -92,9 +92,6 @@
             <div class="notice {{ message.tags }}">{{ message }}</div>
           {% endfor %}
         {% endif %}
-        {% block notices %}
-          <div class="notice success">Welcome to Standup v2! We rewrote it and pushed it out on September 23rd. If you have any problems, see <a href="https://wiki.mozilla.org/Standup">the Standup wiki page</a> for help.</div>
-        {% endblock %}
       </div>
       {% block before_content %}
         {% if user.is_authenticated() %}


### PR DESCRIPTION
This notice is temporary. At this point, we're pretty far into Standup v2 that
we don't need it anymore.