### PR TITLE
Fixed initial migrations.

### DIFF
--- a/standup/status/migrations/0005_add_team_user_id.py
+++ b/standup/status/migrations/0005_add_team_user_id.py
@@ -21,11 +21,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='teamuser',
-            name='id',
-            field=models.AutoField(serialize=False, auto_created=True, verbose_name='ID')
-        ),
         migrations.RunPython(fill_teamuser_ids, reverse_code=lambda x, y: None),
         migrations.AlterField(
             model_name='teamuser',


### PR DESCRIPTION
While installing the project locally I've stumbled upon a migration error where I had to update a migration file to see it going away.

The error was:

```
➜  standup git:(master) make run
/usr/local/bin/docker-compose up web
Creating standup_db_1
Creating standup_web_1
Attaching to standup_web_1
web_1         | + export SERVER_MODE=dev
web_1         | + SERVER_MODE=dev
web_1         | + export LOG_LEVEL=info
web_1         | + LOG_LEVEL=info
web_1         | + exec supervisord -c etc/supervisord.conf
web_1         | 2016-12-27 11:59:30,969 CRIT Supervisor running as root (no user in config file)
web_1         | 2016-12-27 11:59:30,971 INFO supervisord started with pid 1
web_1         | 2016-12-27 11:59:31,973 INFO spawned: 'standup' with pid 9
web_1         | + urlwait
web_1         | 2016-12-27 11:59:32,978 INFO success: standup entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
web_1         | + ./bin/run-common.sh
web_1         | + python3 manage.py migrate --noinput --fake-initial
web_1         | Operations to perform:
web_1         |   Synchronize unmigrated apps: pipeline, auth0, raven_contrib_django, django_jinja_markdown, staticfiles, _humanize, django_gravatar, django_jinja, messages
web_1         |   Apply all migrations: auth, sessions, admin, api, contenttypes, status
web_1         | Synchronizing apps without migrations:
web_1         |   Creating tables...
web_1         |     Running deferred SQL...
web_1         |   Installing custom SQL...
web_1         | Running migrations:
web_1         |   Rendering model states... DONE
web_1         |   Applying contenttypes.0001_initial... OK
web_1         |   Applying auth.0001_initial... OK
web_1         |   Applying admin.0001_initial... OK
web_1         |   Applying api.0001_initial... OK
web_1         |   Applying contenttypes.0002_remove_content_type_name... OK
web_1         |   Applying auth.0002_alter_permission_name_max_length... OK
web_1         |   Applying auth.0003_alter_user_email_max_length... OK
web_1         |   Applying auth.0004_alter_user_username_opts... OK
web_1         |   Applying auth.0005_alter_user_last_login_null... OK
web_1         |   Applying auth.0006_require_contenttypes_0002... OK
web_1         |   Applying sessions.0001_initial... OK
web_1         |   Applying status.0001_initial... OK
web_1         |   Applying status.0002_standupuser_user... OK
web_1         |   Applying status.0003_make_users... OK
web_1         |   Applying status.0004_auto_20160902_2117... OK
web_1         |   Applying status.0005_add_team_user_id...Traceback (most recent call last):
web_1         |   File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 64, in execute
web_1         |     return self.cursor.execute(sql, params)
web_1         | psycopg2.ProgrammingError: column "id" of relation "team_users" already exists
```

Disclaimer:

![](http://www.evolveyourweddingbusiness.com/wp-content/uploads/2014/12/0842421504b474e9ba1adb650f17996a145ff1290de6596821915c3ea53218af.jpg)

At least this allowed me to have the project running okay on my machine.