### PR TITLE
Add monkeypatch to prevent connection closing for memcachier

### DIFF
--- a/standup/wsgi.py
+++ b/standup/wsgi.py
@@ -9,10 +9,15 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 
 import os
 
+from django.core.cache.backends.memcached import BaseMemcachedCache
 from django.core.wsgi import get_wsgi_application
 
 from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
+
+# Fix django closing connection to MemCachier after every request (#11331)
+# per the MemCachier docs.
+BaseMemcachedCache.close = lambda self, **kwargs: None
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standup.settings")
 


### PR DESCRIPTION
This is mentioned at the bottom of the Django section here:

https://devcenter.heroku.com/articles/memcachier#django

> Finally, we also strongly recommend that you place the following code in your wsgi.py file to correct a serious performance bug (#11331) with Django and memcached. The fix enables persistent connections under Django, which by default uses a new connection for each request:
>
> ```
> # Fix django closing connection to MemCachier after every request (#11331)
> from django.core.cache.backends.memcached import BaseMemcachedCache
> BaseMemcachedCache.close = lambda self, **kwargs: None
> ```