### PR TITLE
Cache reworking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,9 +67,6 @@ django-cache-url==1.3.1 \
 tabulate==0.7.7 \
     --hash=sha256:1f07f6252b20cdc4ed744b598b5fa8362638988b50a62f3e2ad76c97fc02eef2 \
     --hash=sha256:83a0b8e17c09f012090a50e1e97ae897300a72b35e0c86c0b53d3bd2ae86d8c6
-django-pylibmc==0.6.1 \
-    --hash=sha256:02b591933a029eb552388cced713028f3c6cbb021639fc8de388bd1ca87981d4 \
-    --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
 simplejson==3.10.0 \
     --hash=sha256:8b478dd885fd7184d38797939ccd508e7feb77875058a94e5f09a4e0c67a53c2 \
     --hash=sha256:7a8daeaea5d8b846a7cd6d76aa1006cc15c2f51eba3abafd6948824ef166ba60 \
@@ -90,8 +87,3 @@ simplejson==3.10.0 \
     --hash=sha256:e633def17eedd2d202437daeb8fda6f379d51a34de8b809800e2737d3e7363f9 \
     --hash=sha256:370f2b68a93fb533b537dfacc13300928f794e7dbdf7c72769d80432ea71631a \
     --hash=sha256:7e6f55c72388afa83c38fda0d5dab710f364476b661d8b5441ab79c1d402e9be
-django-heroku-memcacheify==1.0.0 \
-    --hash=sha256:76811edb1521bd22b2bf8147afc47685ec8317adf2f7e5f4feccb975409883a1 \
-    --hash=sha256:971c63f9af5bee2884bbfd308457b6675b35b89a33cf42c1c4f0a554c324a563
-pylibmc==1.5.1 \
-    --hash=sha256:ecba261859c3e1ba3365389cb4f4dfffb7e02120a9f57a288cacf2f42c45cdd6

--- a/standup/auth0/README.rst
+++ b/standup/auth0/README.rst
@@ -23,8 +23,14 @@ Specs
 Requirements
 ============
 
+You'll need:
+
 * Python 3
 * Django 1.8+
+
+If you want to use the cache-based ``id_token`` expiration checking, you'll also
+need:
+
 * A caching backend (locmem if you've got only one node and one process,
   memcached or something real otherwise)
 
@@ -135,4 +141,3 @@ out and redirected to the ``AUTH0_SIGNIN_VIEW``.
     |                             | sends id_token       |
     |                             | < id_token --------- |
     | < Stuff from something ---- |                      |
-

--- a/standup/auth0/middleware.py
+++ b/standup/auth0/middleware.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import logging
 from urllib.parse import urlparse
 
 import requests
@@ -14,6 +15,9 @@ from django.utils import timezone
 
 from standup.auth0.models import IdToken
 from standup.auth0.settings import app_settings
+
+
+logger = logging.getLogger(__name__)
 
 
 class Auth0LookupError(Exception):
@@ -147,6 +151,7 @@ class ValidateIdToken(object):
                 token.save()
 
                 self.update_expiration(request)
+                logger.debug('ValidateIdToken: token renewed for %s' % request.user)
                 return
 
             # If we don't have a new id_token, then it's not valid anymore. We log the user

--- a/standup/auth0/middleware.py
+++ b/standup/auth0/middleware.py
@@ -12,8 +12,8 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils import timezone
 
-from standup.auth0.settings import app_settings
 from standup.auth0.models import IdToken
+from standup.auth0.settings import app_settings
 
 
 class Auth0LookupError(Exception):
@@ -51,17 +51,44 @@ class ValidateIdToken(object):
     example, the user could have been blocked (e.g. leaving the company) if so we need to ask the
     user to log in again.
 
-    We do this using cache.
-
-    # FIXME(willkg): Maybe rework this so that the cache parts are methods that can be
-    # overridden.
-
     """
 
     exception_paths = (
         # Exclude the AUTH0_CALLBACK_URL path, otherwise this can loop
         urlparse(app_settings.AUTH0_CALLBACK_URL).path,
     )
+
+    def is_expired(self, request):
+        """Returns whether or not the id_token is expired
+
+        For simplicity purposes, this returns False if there is a token and it's
+        not expired and True in all other cases.
+
+        :arg request: the Django Request object which has a ``.user`` property with
+            the user in question
+
+        :returns: bool--False if not expired and True in all other cases
+
+        """
+        try:
+            token = IdToken.objects.get(user=request.user)
+        except IdToken.DoesNotExist:
+            # If there's no id_token, then we treat it as expired.
+            return True
+
+        # Return whether the id_token expiration has passed
+        return bool(token.expire < timezone.now())
+
+    def update_expiration(self, request):
+        """Updates any bookkeeping related to checking expiration
+
+        :arg request: the Django Request object which has a ``.user`` property with
+            the user in question
+
+        """
+        # Prior to this getting called, the middleware code updates the db record, so this is a
+        # no-op
+        pass
 
     def process_request(self, request):
         if (
@@ -78,11 +105,7 @@ class ValidateIdToken(object):
             if domain not in app_settings.AUTH0_ID_TOKEN_DOMAINS:
                 return
 
-            cache_key = 'auth0:renew_id_token:%s' % request.user.id
-
-            # Look up expiration in cache to see if id_token needs to be renewed
-            # FIXME(willkg): Try named cache and if that doesn't exist, fall back to default.
-            if cache.get(cache_key):
+            if not self.is_expired(request):
                 return
 
             # The id_token has expired, so we renew it now
@@ -118,12 +141,12 @@ class ValidateIdToken(object):
                 return HttpResponseRedirect(reverse(app_settings.AUTH0_SIGNIN_VIEW))
 
             if new_id_token:
-                # Save new token and re-up it in cache--all set!
+                # Save new token and we're all set
                 token.id_token = new_id_token
                 token.expire = timezone.now() + timedelta(seconds=app_settings.AUTH0_ID_TOKEN_EXPIRY)
                 token.save()
 
-                cache.set(cache_key, True, app_settings.AUTH0_ID_TOKEN_EXPIRY)
+                self.update_expiration(request)
                 return
 
             # If we don't have a new id_token, then it's not valid anymore. We log the user
@@ -136,3 +159,18 @@ class ValidateIdToken(object):
             )
             logout(request)
             return HttpResponseRedirect(reverse(app_settings.AUTH0_SIGNIN_VIEW))
+
+
+class ValidateIdTokenUsingCache(ValidateIdToken):
+    """Uses cache to check id_token expiration"""
+    def is_expired(self, request):
+        cache_key = 'auth0:renew_id_token:%s' % request.user.id
+
+        # Look up expiration in cache to see if id_token needs to be renewed
+        # FIXME(willkg): Try named cache and if that doesn't exist, fall back to default.
+        return bool(cache.get(cache_key))
+
+    def update_expiration(self, request):
+        cache_key = 'auth0:renew_id_token:%s' % request.user.id
+
+        cache.set(cache_key, True, app_settings.AUTH0_ID_TOKEN_EXPIRY)

--- a/standup/settings.py
+++ b/standup/settings.py
@@ -1,10 +1,8 @@
-import os
 from pathlib import Path
 
 from everett.manager import ConfigManager, ConfigEnvFileEnv, ConfigOSEnv, ListOf
 import dj_database_url
 import django_cache_url
-from memcacheify import memcacheify
 
 
 ROOT_PATH = Path(__file__).resolve().parents[1]
@@ -59,7 +57,6 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.cache.UpdateCacheMiddleware',
     'django.middleware.security.SecurityMiddleware',
 
     'standup.status.middleware.EnforceHostnameMiddleware',
@@ -74,7 +71,6 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.cache.FetchFromCacheMiddleware',
 
     'standup.auth0.middleware.ValidateIdToken',
     'standup.status.middleware.NewUserProfileMiddleware',
@@ -146,18 +142,9 @@ DATABASES = {
                       default='sqlite:///db.sqlite3')
 }
 
-if os.environ.get('MEMCACHIER_SERVERS', ''):
-    # If MEMCACHIER_SERVERS is in the os.environ, then let the memcacheify lib
-    # configure everything. It's probably good enough.
-    CACHES = memcacheify()
-else:
-    CACHES = {
-        'default': config('CACHE_URL', parser=django_cache_url.parse, default='locmem:default')
-    }
-
-CACHE_MIDDLEWARE_SECONDS = config('CACHE_MIDDLEWARE_SECONDS', default='30', parser=int)
-CACHE_FEEDS_SECONDS = config('CACHE_FEEDS_SECONDS', default='1800', parser=int)  # 30 min
-
+CACHES = {
+    'default': config('CACHE_URL', parser=django_cache_url.parse, default='locmem:default')
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/

--- a/standup/status/urls.py
+++ b/standup/status/urls.py
@@ -1,12 +1,10 @@
 from django.conf import settings
 from django.conf.urls import url
-from django.views.decorators.cache import cache_page
 
 from . import views
 
 
 SLUG_RE = r'(?P<slug>[-a-zA-Z0-9_@]+)'
-cache_feed = cache_page(settings.CACHE_FEEDS_SECONDS)
 
 urlpatterns = [
     url(r'^$', views.HomeView.as_view(), name='status.index'),
@@ -24,10 +22,10 @@ urlpatterns = [
     url(r'^login-form/$', views.LoginView.as_view(), name='users.loginform'),
 
     # feeds
-    url(r'^statuses.xml$', cache_feed(views.MainFeed()), name='status.index_feed'),
-    url(r'^user/{}.xml$'.format(SLUG_RE), cache_feed(views.UserFeed()), name='status.user_feed'),
-    url(r'^team/{}.xml$'.format(SLUG_RE), cache_feed(views.TeamFeed()), name='status.team_feed'),
-    url(r'^project/{}.xml$'.format(SLUG_RE), cache_feed(views.ProjectFeed()),
+    url(r'^statuses.xml$', views.MainFeed(), name='status.index_feed'),
+    url(r'^user/{}.xml$'.format(SLUG_RE), views.UserFeed(), name='status.user_feed'),
+    url(r'^team/{}.xml$'.format(SLUG_RE), views.TeamFeed(), name='status.team_feed'),
+    url(r'^project/{}.xml$'.format(SLUG_RE), views.ProjectFeed(),
         name='status.project_feed'),
     url(r'^statistics/$', views.statistics, name='status.statistics'),
 

--- a/standup/status/views.py
+++ b/standup/status/views.py
@@ -13,9 +13,7 @@ from django.http import Http404
 from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseForbidden, HttpResponseRedirect)
 from django.shortcuts import render
-from django.utils.decorators import method_decorator
 from django.utils.feedgenerator import Atom1Feed
-from django.views.decorators.cache import cache_page, never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import DetailView, TemplateView, UpdateView
@@ -132,7 +130,6 @@ class ProfileView(UpdateView):
     success_url = '/profile/'
     new_profile = False
 
-    @method_decorator(never_cache)
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated():
             messages.error(request, 'You must be signed in to view your profile. '
@@ -273,7 +270,6 @@ def csp_violation_capture(request):
     return HttpResponse('Captured CSP violation, thanks for reporting.')
 
 
-@cache_page(60 * 60 * 24 * 365)
 def robots_txt(request):
     if settings.ROBOTS_ALLOW:
         content = ''

--- a/standup/wsgi.py
+++ b/standup/wsgi.py
@@ -9,15 +9,10 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 
 import os
 
-from django.core.cache.backends.memcached import BaseMemcachedCache
 from django.core.wsgi import get_wsgi_application
 
 from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
-
-# Fix django closing connection to MemCachier after every request (#11331)
-# per the MemCachier docs.
-BaseMemcachedCache.close = lambda self, **kwargs: None
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "standup.settings")
 


### PR DESCRIPTION
This fixes everything for issue #334:

1. removes all caching and page caching
2. switches us back to using locmem
3. removes all the memcached stuff
4. changes auth0 `id_token` renewal to use the db and not cache--but also adds an untested cache-based middleware

@pmac Quick r?