### PR TITLE
Fix the 0005_add_team_user_id migration

### DIFF
--- a/standup/status/migrations/0005_add_team_user_id.py
+++ b/standup/status/migrations/0005_add_team_user_id.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import migrations, models
+from django.db import migrations, models  # noqa
 
+# Note: This was written when we needed to migrate the Standup db from the old schema to the new
+# one. We don't need to do that anymore and this migration prevents contributors from creating fresh
+# databases, so I'm commenting it out.
 
-def fill_teamuser_ids(apps, schema_editor):
-    """Fill in unique IDs for TeamUser rows"""
-    TeamUser = apps.get_model('status', 'TeamUser')
-    index = 0
-    for tu in TeamUser.objects.all():
-        index += 1
-        tu.id = index
-        tu.save()
+# def fill_teamuser_ids(apps, schema_editor):
+#     """Fill in unique IDs for TeamUser rows"""
+#     TeamUser = apps.get_model('status', 'TeamUser')
+#     index = 0
+#     for tu in TeamUser.objects.all():
+#         index += 1
+#         tu.id = index
+#         tu.save()
 
 
 class Migration(migrations.Migration):
@@ -21,15 +24,15 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
-            model_name='teamuser',
-            name='id',
-            field=models.AutoField(serialize=False, auto_created=True, verbose_name='ID')
-        ),
-        migrations.RunPython(fill_teamuser_ids, reverse_code=lambda x, y: None),
-        migrations.AlterField(
-            model_name='teamuser',
-            name='id',
-            field=models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)
-        )
+        # migrations.AddField(
+        #     model_name='teamuser',
+        #     name='id',
+        #     field=models.AutoField(serialize=False, auto_created=True, verbose_name='ID')
+        # ),
+        # migrations.RunPython(fill_teamuser_ids, reverse_code=lambda x, y: None),
+        # migrations.AlterField(
+        #     model_name='teamuser',
+        #     name='id',
+        #     field=models.AutoField(serialize=False, auto_created=True, verbose_name='ID', primary_key=True)
+        # )
     ]


### PR DESCRIPTION
When we migrated the Standup data from the old db schema to the new one, we
skipped the 0001_initial migration because we already had a bunch of tables and
data. However, we needed to make changes to those tables.

This migration adds an "id" column to the team table, but it already has one
from the 0001_initial migration.

Given that this migration is only helpful when updating an old Standup db, I
commented out the code and turned it into a no-op.

This fixes #317.