### PR TITLE
Add hard-coded message

### DIFF
--- a/standup/status/jinja2/base.html
+++ b/standup/status/jinja2/base.html
@@ -87,6 +87,10 @@
 
     <div id="main-content" class="container_12 cf">
       <div id="main-notices" class="grid_12">
+        <div class="notice success">
+          We've switched the way we use Auth0. If you have problems, see
+          <a href="{{ settings.HELP_FAQ_URL }}">our FAQ</a>.
+        </div>
         {% if messages %}
           {% for message in messages %}
             <div class="notice {{ message.tags }}">{{ message }}</div>


### PR DESCRIPTION
We're transitioning auth methods again, so this helps notify users. There's
another issue for building in a messaging system that's db-backed, so we don't
have to keep doing this, but that's not done, yet.