### PR TITLE
Disable update API

### DIFF
--- a/standup/api/tests/test_views.py
+++ b/standup/api/tests/test_views.py
@@ -4,6 +4,8 @@ from django.core.urlresolvers import reverse
 from django.utils.encoding import force_bytes
 from django.test import Client, TestCase
 
+import pytest
+
 from standup.api.tests.factories import SystemTokenFactory
 from standup.status.models import (
     Project,
@@ -308,6 +310,7 @@ class TestStatusDelete(APITestCase):
         assert resp.content == b'{"error": "You cannot delete this status."}'
 
 
+@pytest.mark.xfail(reason='Update is disabled until we reimplement it')
 class TestUpdateUser(APITestCase):
     def test_update_name(self):
         token = SystemTokenFactory.create()

--- a/standup/api/urls.py
+++ b/standup/api/urls.py
@@ -6,5 +6,6 @@ from . import views
 urlpatterns = [
     url(r'^v1/status/(?P<pk>\d{1,8})/$', views.StatusDelete.as_view(), name='api.status-delete'),
     url(r'^v1/status/', views.StatusCreate.as_view(), name='api.status-create'),
-    url(r'^v1/user/(?P<username>[a-zA-Z0-9]+)/$', views.UpdateUser.as_view(), name='api.user-update'),
+    # FIXME(willkg): Re-enable this after we've reimplemented the UpdateUser view
+    # url(r'^v1/user/(?P<username>[a-zA-Z0-9]+)/$', views.UpdateUser.as_view(), name='api.user-update'),
 ]

--- a/standup/api/views.py
+++ b/standup/api/views.py
@@ -218,6 +218,8 @@ class StatusDelete(AuthenticatedAPIView):
         return HttpResponseJSON({'id': status_id})
 
 
+# FIXME(willkg): This should get rewritten to re-use the ProfileForm so they're
+# in lockstep.
 class UpdateUser(AuthenticatedAPIView):
     def post(self, request, username):
         # token = request.auth_token


### PR DESCRIPTION
The update API endpoint needs to be rewritten. This disables it until we do
that.