### PR TITLE
Remove github_handle

### DIFF
--- a/standup/api/tests/test_views.py
+++ b/standup/api/tests/test_views.py
@@ -342,21 +342,6 @@ class TestUpdateUser(APITestCase):
         standupuser = StandupUser.objects.get(pk=standupuser.id)
         assert standupuser.email == 'lor@example.com'
 
-    def test_update_github_handle(self):
-        token = SystemTokenFactory.create()
-        standupuser = StandupUserFactory.create(github_handle='data')
-
-        resp = self.client.post_json(
-            reverse('api.user-update', kwargs={'username': standupuser.irc_nick}),
-            payload={
-                'api_key': token.token,
-                'github_handle': 'lor',
-            }
-        )
-        assert resp.status_code == 200
-        standupuser = StandupUser.objects.get(pk=standupuser.id)
-        assert standupuser.github_handle == 'lor'
-
     def test_user_does_not_exist(self):
         token = SystemTokenFactory.create()
 

--- a/standup/api/views.py
+++ b/standup/api/views.py
@@ -235,8 +235,6 @@ class UpdateUser(AuthenticatedAPIView):
             user.name = request.json_body['name']
         if 'email' in request.json_body:
             user.user.email = request.json_body['email']
-        if 'github_handle' in request.json_body:
-            user.github_handle = request.json_body['github_handle']
 
         user.save()
         user.user.save()

--- a/standup/status/admin.py
+++ b/standup/status/admin.py
@@ -21,6 +21,6 @@ class TeamAdmin(admin.ModelAdmin):
 
 @admin.register(StandupUser)
 class StandupUserAdmin(admin.ModelAdmin):
-    list_display = ['name', 'slug', 'github_handle']
-    search_fields = ['name', 'slug', 'github_handle']
+    list_display = ['name', 'slug', 'irc_nick']
+    search_fields = ['name', 'slug', 'irc_nick']
     filter_horizontal = ['teams']

--- a/standup/status/forms.py
+++ b/standup/status/forms.py
@@ -22,8 +22,8 @@ class ProfileForm(forms.ModelForm):
     # as them.
     class Meta:
         model = StandupUser
-        fields = ['name', 'irc_nick', 'github_handle']
+        fields = ['name', 'irc_nick']
         labels = {
+            'name': 'Full name',
             'irc_nick': 'IRC Handle',
-            'github_handle': 'Github Handle',
         }

--- a/standup/status/management/commands/finduser.py
+++ b/standup/status/management/commands/finduser.py
@@ -18,8 +18,10 @@ class Command(BaseCommand):
 
         self.stdout.write('Searching for: %s' % text)
 
+        # FIXME(willkg): Redo this so that it's easier to keep the row headers in lockstep with row
+        # contents without doing it by hand.
         rows = [
-            ['user_id', 'username', 'email', 'name', 'slug', 'irc', 'github', '# statuses', 'last login', 'created']
+            ['user_id', 'username', 'email', 'name', 'slug', 'irc', '# statuses', 'last login', 'created']
         ]
 
         id_to_data = {}
@@ -41,7 +43,6 @@ class Command(BaseCommand):
                 '',
                 '',
                 '',
-                '',
                 user.last_login,
                 user.date_joined
             ]
@@ -52,8 +53,7 @@ class Command(BaseCommand):
             StandupUser.objects.filter(
                 Q(name__icontains=text) |
                 Q(slug__icontains=text) |
-                Q(irc_nick__icontains=text) |
-                Q(github_handle__icontains=text)
+                Q(irc_nick__icontains=text)
             )
             .order_by('id')
         )
@@ -65,7 +65,6 @@ class Command(BaseCommand):
                 user.name,
                 user.slug,
                 user.irc_nick,
-                user.github_handle,
                 user.statuses.count(),
                 user.user.last_login,
                 user.user.date_joined

--- a/standup/status/migrations/0009_remove_standupuser_github_handle.py
+++ b/standup/status/migrations/0009_remove_standupuser_github_handle.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0008_github_handle_fixes'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='standupuser',
+            name='github_handle',
+        ),
+    ]

--- a/standup/status/models.py
+++ b/standup/status/models.py
@@ -78,7 +78,6 @@ class StandupUser(models.Model):
         max_length=100, blank=True, null=True, unique=True,
         help_text='IRC nick for this particular user'
     )
-    github_handle = models.CharField(max_length=100, blank=True, null=True)
     teams = models.ManyToManyField(Team, related_name='users', through='TeamUser')
 
     class Meta:
@@ -114,7 +113,6 @@ class StandupUser(models.Model):
         data['irc_nick'] = self.irc_nick
         # FIXME: Should we be providing email addresses publicly via the api?
         # data['email'] = self.user.email
-        data['github_handle'] = self.github_handle
         data['is_staff'] = self.user.is_staff
         return data
 

--- a/standup/status/tests/factories.py
+++ b/standup/status/tests/factories.py
@@ -48,7 +48,6 @@ class StandupUserFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     slug = factory.LazyAttribute(lambda obj: slugify(obj.user.username))
     irc_nick = factory.Faker('user_name')
-    github_handle = factory.LazyAttribute(lambda obj: obj.user.username)
     # FIXME: teams
 
 


### PR DESCRIPTION
We stopped using it a while back when we switched to auth0, but we kept it
around in case it helped us merge user accounts. I haven't found it helpful so
far, so this removes it.