### PR TITLE
Switch from nickname-based username to a hash

### DIFF
--- a/standup/status/auth.py
+++ b/standup/status/auth.py
@@ -1,4 +1,5 @@
 from django.db import IntegrityError
+from django.util.text import slugify
 
 from standup.status.models import StandupUser
 
@@ -38,13 +39,13 @@ def create_profile(user, is_new, **kwargs):
     except StandupUser.DoesNotExist:
         pass
 
-    for slug in unique_string_generator(user.username):
-        # FIXME: run slugify on slug
+    email_name = user.email.split('@', 1)[0]
+    for possible_slug in unique_string_generator(email_name):
         try:
             return {
                 'profile': StandupUser.objects.create(
                     user=user,
-                    slug=slug
+                    slug=slugify(possible_slug)
                 )
             }
         except IntegrityError:


### PR DESCRIPTION
This changes the auth0 code from using the `user_info['nickname']` field for
usernames and instead generating the username from hashing the email address
which we're using as a unique identifier. This fixes all kinds of problems.

The only part of this that affects Standup is the part where we're generating User instances with a fresh username. Otherwise we don't use the username anywhere including when matching OIDC identities to Standup identities.

Fixes #349.