### PR TITLE
Fix email check

### DIFF
--- a/standup/auth0/pipeline.py
+++ b/standup/auth0/pipeline.py
@@ -142,7 +142,7 @@ def reject_unverified_email(request, user_info, **kwargs):
     :returns: ``HttpResponseRedirect`` or None
 
     """
-    if not user_info['email_verified']:
+    if not user_info.get('email_verified', False):
         # If inactive, add message and redirect to login page
         messages.error(
             request,


### PR DESCRIPTION
If email_verified isn't in user_info, treat it as if it were False.

Fixes #362.