### PR TITLE
Fix teams and users

### DIFF
--- a/standup/status/admin.py
+++ b/standup/status/admin.py
@@ -14,16 +14,15 @@ class ProjectAdmin(admin.ModelAdmin):
 
 @admin.register(Team)
 class TeamAdmin(admin.ModelAdmin):
-    fields = ['name', 'slug']
     list_display = ['name', 'slug']
     prepopulated_fields = {'slug': ['name']}
+    filter_horizontal = ['users']
 
 
 @admin.register(StandupUser)
 class StandupUserAdmin(admin.ModelAdmin):
     list_display = ['name', 'slug', 'irc_nick']
     search_fields = ['name', 'slug', 'irc_nick']
-    filter_horizontal = ['teams']
 
 
 @admin.register(Status)

--- a/standup/status/jinja2/status/team.html
+++ b/standup/status/jinja2/status/team.html
@@ -6,6 +6,18 @@
 {% endblock %}
 
 {% block content %}
+  <div>
+    <div class="grid_4 alpha"></div>
+    <div class="grid_7 middle" >
+      <h2>Team: {{ team.name }}</h2>
+      <p>
+        Members:
+        {% for u in team.users.all() %}
+          <a href="{{ u.get_absolute_url() }}">{{ u.name }}</a>
+        {% endfor %}
+      </p>
+    </div>
+  </div>
   <div class="grid_12">
     {{ status_updates(statuses, url=url('status.team', slug=team.slug)) }}
   </div>

--- a/standup/status/migrations/0012_teamusercopy.py
+++ b/standup/status/migrations/0012_teamusercopy.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0011_remove_content_html'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TeamUserCopy',
+            fields=[
+                ('id', models.AutoField(serialize=False, verbose_name='ID', primary_key=True, auto_created=True)),
+                ('team_id', models.IntegerField()),
+                ('user_id', models.IntegerField()),
+            ],
+        ),
+    ]

--- a/standup/status/migrations/0013_backup_teamuser.py
+++ b/standup/status/migrations/0013_backup_teamuser.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def copy_to_teamusercopy(apps, schema_editor):
+    """Copy from TeamUser to TeamUserCopy"""
+    TeamUser = apps.get_model('status', 'TeamUser')
+    TeamUserCopy = apps.get_model('status', 'TeamUserCopy')
+
+    for teamuser in TeamUser.objects.all():
+        if TeamUserCopy.objects.filter(team_id=teamuser.team_id, user_id=teamuser.user_id).count() == 0:
+            TeamUserCopy.objects.create(team_id=teamuser.team_id, user_id=teamuser.user_id)
+            print('Created %s %s' % (teamuser.team_id, teamuser.user_id))
+        else:
+            print('Already exists... skipping')
+
+
+def copy_from_teamusercopy(apps, schema_editor):
+    """Copy from TeamUserCopy back to TeamUser"""
+    TeamUser = apps.get_model('status', 'TeamUser')
+    TeamUserCopy = apps.get_model('status', 'TeamUserCopy')
+
+    for teamusercopy in TeamUserCopy.objects.all():
+        if TeamUser.objects.filter(team_id=teamusercopy.team_id, user_id=teamusercopy.user_id).count() == 0:
+            TeamUser.objects.create(team_id=teamusercopy.team_id, user_id=teamusercopy.user_id)
+            print('Created %s %s' % (teamusercopy.team_id, teamusercopy.user_id))
+        else:
+            print('Already exists... skipping')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0012_teamusercopy'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_to_teamusercopy, copy_from_teamusercopy)
+    ]

--- a/standup/status/migrations/0014_remove_teamuser.py
+++ b/standup/status/migrations/0014_remove_teamuser.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0013_backup_teamuser'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='teamuser',
+            unique_together=set([]),
+        ),
+        migrations.RemoveField(
+            model_name='teamuser',
+            name='team',
+        ),
+        migrations.RemoveField(
+            model_name='teamuser',
+            name='user',
+        ),
+        migrations.RemoveField(
+            model_name='standupuser',
+            name='teams',
+        ),
+        migrations.DeleteModel(
+            name='TeamUser',
+        ),
+    ]

--- a/standup/status/migrations/0015_team_users.py
+++ b/standup/status/migrations/0015_team_users.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0014_remove_teamuser'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='team',
+            name='users',
+            field=models.ManyToManyField(related_name='teams', to='status.StandupUser'),
+        ),
+    ]

--- a/standup/status/migrations/0016_restore_teamuser.py
+++ b/standup/status/migrations/0016_restore_teamuser.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def teamusercopy_to_teams(apps, schema_editor):
+    StandupUser = apps.get_model('status', 'StandupUser')
+    Team = apps.get_model('status', 'Team')
+    TeamUserCopy = apps.get_model('status', 'TeamUserCopy')
+
+    for tuc in TeamUserCopy.objects.all():
+        # Get the user and team
+        suser = StandupUser.objects.get(id=tuc.user_id)
+        team = Team.objects.get(id=tuc.team_id)
+
+        # Add the team to the user
+        suser.teams.add(team)
+        print('Adding %s to team %s' % (suser.id, team.id))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('status', '0015_team_users'),
+    ]
+
+    operations = [
+        migrations.RunPython(teamusercopy_to_teams, lambda apps, schema_editor: None)
+    ]


### PR DESCRIPTION
Previously, we had a TeamUser m2m model and that made lots of things hard
including the managing teams in the Django admin.

This does a meticulous set of migrations to copy that data to an ephemeral
table, nix that m2m model and recreate the relationship using Django magic.