### PR TITLE
Switch dockerfile base to mozmeao/base:pythode-3.6-6.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,7 @@ build-base:
 	touch .docker-build-base
 
 build: .docker-build-base
-	${DOCKERCOMPOSE} -f docker-compose.build.yml build base builder web
-	${DOCKERCOMPOSE} run -u $(CURRENT_USER) assets
-	${DOCKERCOMPOSE} -f docker-compose.build.yml build code
+	${DOCKERCOMPOSE} -f docker-compose.build.yml build web
 	touch .docker-build
 
 rebuild: clean .docker-build

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -7,26 +7,10 @@ services:
       dockerfile: docker/standup_base
     image: local/standup_base
 
-  builder:
-    build:
-      context: .
-      dockerfile: docker/standup_builder
-    image: local/standup_builder
-    depends_on:
-      - base
-
-  code:
-    build:
-      context: .
-      dockerfile: docker/standup_code
-    image: local/standup_code
-    depends_on:
-      - base
-
   web:
     build:
       context: .
       dockerfile: docker/standup_dev
     image: local/standup_dev
     depends_on:
-      - builder
+      - base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,11 @@ services:
 
   # run the site in a prod-like environment
   prod:
-    image: local/standup_code
+    image: local/standup_base
     ports:
       - "8000:8000"
-    volumes:
-      - .:/app
+    # volumes:
+    #   - .:/app
     links:
       - db
     environment:
@@ -39,7 +39,7 @@ services:
 
   # build static files
   assets:
-    image: local/standup_builder
+    image: local/standup_base
     environment:
       - SITE_URL=http://localhost:8000/
       - DEBUG=False

--- a/docker/standup_base
+++ b/docker/standup_base
@@ -1,18 +1,26 @@
-FROM mozmeao/base:python-3.6-alpine
+FROM mozmeao/base:pythode-3.6-6.10
 
-RUN apk add --update --no-cache postgresql-dev
+RUN apt-install libpq-dev postgresql-client build-essential
 
-ENV PATH=/usr/lib/node_modules/standup/node_modules/.bin:$PATH
+ENV PATH=/usr/local/lib/node_modules/standup/node_modules/.bin:$PATH
 ENV PIPELINE_LESS_BINARY=lessc
 ENV PIPELINE_UGLIFYJS_BINARY=uglifyjs
 ENV PIPELINE_CLEANCSS_BINARY=cleancss
 
 # Project settings
-ENV DJANGO_SETTINGS_MODULE standup.settings
+ENV DJANGO_SETTINGS_MODULE=standup.settings
 
 EXPOSE 8000
 WORKDIR /app
-CMD ["/app/bin/run.sh", "prod"]
+CMD ["./bin/run.sh", "prod"]
+
+COPY package.json ./
+RUN npm install -g
 
 COPY requirements.txt ./
 RUN pip install --require-hashes --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+# process static files
+RUN bin/phb-manage.sh collectstatic --noinput

--- a/docker/standup_dev
+++ b/docker/standup_dev
@@ -1,8 +1,6 @@
-FROM local/standup_builder
+FROM local/standup_base
 
-CMD ["/app/bin/run.sh", "dev"]
+CMD ["./bin/run.sh", "dev"]
 
 COPY requirements-dev.txt ./
 RUN pip install --require-hashes --no-cache-dir -r requirements-dev.txt
-
-COPY . /app


### PR DESCRIPTION
Turns out using tini as the entrypoint does not work with Heroku's Docker container runtime. Also I am now more a fan of Debian images than Alpine.

This does move back to having NodeJS installed in the production container, and we could move back to not having that, but I don't see it as a big enough deal to bother with switching to that at present. If anyone feels differently please let me know.