### PR TITLE
Fix .pyup.yml

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -9,10 +9,10 @@ branch: master
 
 # Look at these requirements files
 requirements:
-  - requirements.txt
+  - requirements.txt:
       updates: all
       pin: True
-  - requirements-dev.txt
+  - requirements-dev.txt:
       updates: all
       pin: True
 


### PR DESCRIPTION
Hey @willkg.

Looks like the requirement files were missing a `:`, causing the parsing to fail completely. This was also wrong in the docs, all blame on me!

I'll add a basic online linter like the one from [travis](http://lint.travis-ci.org/) to make this easier. In the meantime you can try to validate it here: http://yaml-online-parser.appspot.com/



