### PR TITLE
Update mozilla-django-oidc to 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -136,9 +136,9 @@ pytz==2018.3 \
     --hash=sha256:5bd55c744e6feaa4d599a6cbd8228b4f8f9ba96de2c38d56f08e534b3c9edf0d \
     --hash=sha256:887ab5e5b32e4d0c86efddd3d055c1f363cbaa583beb8da5e22d2fa2f64d51ef \
     --hash=sha256:410bcd1d6409026fbaa65d9ed33bf6dd8b1e94a499e32168acfc7b332e4095c0
-mozilla-django-oidc==0.5.0 \
-    --hash=sha256:ab6dcccf4841472c1e82244d66503e87ffae0ad7d38d6187fcca54810eceb7a6 \
-    --hash=sha256:56d72b3a35cbe9b313e4ec19a01943d4ca698562476d3387c3ab30e66d33bcf8
+mozilla-django-oidc==0.6.0 \
+    --hash=sha256:4b432410410c685891bb827b9a392e2bb9d6418dd48d650db68f26a07563dbb0 \
+    --hash=sha256:0f21353f376cfc6c52f7dfdf4c09eb5b1af4ad34c3748c0710a2cad008befd20
 python-jose==2.0.2 \
     --hash=sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b \
     --hash=sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165


### PR DESCRIPTION
This picks up the fix for infinite redirect on login when the OIDC OP
returns an error, but the Django session is still valid thus causing
the user to enter a nether-void between two realities from which they
can't escape except by tossing their cookies.

Fixes #412