### PR TITLE
Fix #457: Make textarea vertically resizable

### DIFF
--- a/standup/status/static/less/style.less
+++ b/standup/status/static/less/style.less
@@ -656,9 +656,10 @@ input[type='text'],
       float: right;
       font-family: Helvetica, Arial, sans-serif;
       height: 92px;
+      min-height: 92px;
       margin-bottom: 20px;
       padding: 12px 20px;
-      resize: none;
+      resize: vertical;
       width: 530px;
 
       &::-webkit-input-placeholder {


### PR DESCRIPTION
This makes the "what's your status?" textarea vertically resizable with a handle, with `resize` style.
The minimum and initial height is the current height.

This works on Firefox, Safari, and Chrome, but not on Edge.
https://developer.mozilla.org/en-US/docs/Web/CSS/resize
Given that it's optional enhancement feature, would it be fine?

The resize handle is partially hidden because the textarea has round border, but it's almost visible on above supported browsers (tested on macOS, debian with xfce, and windows 10)

I've first tried making it also horizontally resizable, but it has unexpected behavior because the textarea is aligned to the right.
So, if I grab the handle at the bottom-right of the textarea and drag it to right, the left side of the textarea grows to the left.
so I'd like to make it only vertically resizable.
